### PR TITLE
Add logging, update error check

### DIFF
--- a/strands-command/scripts/javascript/process-input.cjs
+++ b/strands-command/scripts/javascript/process-input.cjs
@@ -45,7 +45,9 @@ async function determineBranch(github, context, issueId, mode, isPullRequest) {
       });
       console.log(`Created branch ${branchName}`);
     } catch (error) {
-      if (error.status === 422 || error.message?.includes('already exists')) {
+      console.log(`Error message: ${String(error)}`)
+      console.log(`Error JSON: ${JSON.stringify(error)}`)
+      if (error.message?.includes('already exists')) {
         console.log(`Branch ${branchName} already exists`);
       } else {
         console.error("Unable to create branch. Make sure you have given this job step `content: write` permission.")


### PR DESCRIPTION
Update strands command error check for existing branches. `422` can sometimes result in a permission error instead of an existing branch error:
- Failed run with logs: https://github.com/Unshure/docs/actions/runs/21218961321/job/61048432868

failed logs:
```
Implementer started on an issue, attempting to create a branch for implementation.
Error message: HttpError: Reference update failed
Unable to create branch. Make sure you have given this job step `content: write` permission.
Failed: Reference update failed
Error: {"name":"HttpError","status":422,"response":{"url":"https://api.github.com/repos/Unshure/docs/git/refs","status":422,"headers":{"access-control-allow-origin":"*","access-control-expose-headers":"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset","content-length":"131","content-security-policy":"default-src 'none'","content-type":"application/json; charset=utf-8","date":"Wed, 21 Jan 2026 17:21:02 GMT","referrer-policy":"origin-when-cross-origin, strict-origin-when-cross-origin","server":"github.com","strict-transport-security":"max-age=31536000; includeSubdomains; preload","vary":"Accept-Encoding, Accept, X-Requested-With","x-accepted-github-permissions":"contents=write; contents=write,workflows=write","x-content-type-options":"nosniff","x-frame-options":"deny","x-github-ap
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
