### PR TITLE
Langfuse action

### DIFF
--- a/strands-command/actions/strands-agent-runner/action.yml
+++ b/strands-command/actions/strands-agent-runner/action.yml
@@ -11,6 +11,18 @@ inputs:
     description: 'If this action runs with write permission. If this is false, you should run the `strands-write-executor` action after this one with write permission.'
     required: true
     default: 'false'
+  langfuse_public_key:
+    description: 'Langfuse public key for telemetry (optional)'
+    required: false
+    default: ''
+  langfuse_secret_key:
+    description: 'Langfuse secret key for telemetry (optional)'
+    required: false
+    default: ''
+  langfuse_host:
+    description: 'Langfuse host URL for telemetry (optional, e.g., https://cloud.langfuse.com)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -145,6 +157,11 @@ runs:
         # Strands Env Vars
         STRANDS_TOOL_CONSOLE_MODE: 'enabled'
         BYPASS_TOOL_CONSENT: 'true'
+
+        # Langfuse Telemetry (optional)
+        LANGFUSE_PUBLIC_KEY: ${{ inputs.langfuse_public_key }}
+        LANGFUSE_SECRET_KEY: ${{ inputs.langfuse_secret_key }}
+        LANGFUSE_HOST: ${{ inputs.langfuse_host }}
       run: |
         uv run --no-project ${{ runner.temp }}/strands-agent-runner/strands-command/scripts/python/agent_runner.py "$INPUT_TASK"
 

--- a/strands-command/actions/strands-agent-runner/action.yml
+++ b/strands-command/actions/strands-agent-runner/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: ''
   langfuse_host:
-    description: 'Langfuse host URL for telemetry (optional, e.g., https://cloud.langfuse.com)'
+    description: 'Langfuse host URL for telemetry (optional, e.g., https://us.cloud.langfuse.com)'
     required: false
-    default: ''
+    default: 'https://us.cloud.langfuse.com'
 
 runs:
   using: 'composite'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


This pull request adds support for optional Langfuse telemetry configuration to the `strands-agent-runner` GitHub Action. The main changes introduce new input parameters for Langfuse credentials and host, and ensure these values are passed as environment variables when the action runs.

**Langfuse telemetry integration:**

* Added three new optional inputs to `action.yml`: `langfuse_public_key`, `langfuse_secret_key`, and `langfuse_host`, allowing users to supply Langfuse credentials and host URL for telemetry purposes.
* Updated the environment variables in the action runner to include the new Langfuse inputs, so they are available to the agent at runtime.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
