### PR TITLE
Policy accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,8 @@ package-lock.json
 *.swp
 *.swo
 
+# Python virtual env
 .venv
+
+# Environment variables (contains secrets)
+.env

--- a/cdk-evals/.env.example
+++ b/cdk-evals/.env.example
@@ -1,0 +1,2 @@
+# AWS Account IDs that can send messages to the SQS eval queue (comma-separated)
+GITHUB_ACTIONS_ACCOUNT_IDS=123456789012,234567890123

--- a/cdk-evals/bin/app.ts
+++ b/cdk-evals/bin/app.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 import "source-map-support/register";
+import * as dotenv from "dotenv";
 import * as cdk from "aws-cdk-lib";
 import { DashboardStack } from "../lib/dashboard-stack";
 import { EvalPipelineStack } from "../lib/eval-pipeline-stack";
+
+// Load environment variables from .env file (if present)
+dotenv.config();
 
 const app = new cdk.App();
 

--- a/cdk-evals/package.json
+++ b/cdk-evals/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.170.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.170.0-alpha.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.0",
+    "dotenv": "^16.0.0"
   }
 }


### PR DESCRIPTION

This pull request enhances the security and configurability of the SQS evaluation queue in the `cdk-evals` stack by allowing specific AWS accounts to send messages, as defined in a new environment variable. It also adds a dependency to support environment variable loading.

Configuration and security improvements:

* Added a new `GITHUB_ACTIONS_ACCOUNT_IDS` environment variable in `.env.example` to specify which AWS Account IDs are allowed to send messages to the SQS eval queue.
* Updated `EvalPipelineStack` in `eval-pipeline-stack.ts` to read `GITHUB_ACTIONS_ACCOUNT_IDS` from the environment and add a resource-based policy to the SQS queue, granting `sqs:SendMessage` permissions to the specified accounts.

Dependency updates:

* Added the `dotenv` package to `package.json` to support loading environment variables from `.env` files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
