### PR TITLE
checkout pr's from fork for starnds commands to work

### DIFF
--- a/strands-command/actions/strands-agent-runner/action.yml
+++ b/strands-command/actions/strands-agent-runner/action.yml
@@ -42,6 +42,7 @@ runs:
       run: |
         echo "ref=$(jq -r .branch_name strands-parsed-input.json)" >> $GITHUB_OUTPUT
         echo "session_id=$(jq -r .session_id strands-parsed-input.json)" >> $GITHUB_OUTPUT
+        echo "head_repo=$(jq -r '.head_repo // ""' strands-parsed-input.json)" >> $GITHUB_OUTPUT
         echo "system_prompt<<EOF" >> $GITHUB_OUTPUT
         jq -r .system_prompt strands-parsed-input.json >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
@@ -72,6 +73,7 @@ runs:
       uses: actions/checkout@v6
       with:
         ref: ${{ steps.read-input.outputs.ref }}
+        repository: ${{ steps.read-input.outputs.head_repo || github.repository }}
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/strands-command/actions/strands-finalize/action.yml
+++ b/strands-command/actions/strands-finalize/action.yml
@@ -15,20 +15,23 @@ runs:
       run: |
         echo "ref=$(jq -r .branch_name strands-parsed-input.json)" >> $GITHUB_OUTPUT
         echo "issue_id=$(jq -r .issue_id strands-parsed-input.json)" >> $GITHUB_OUTPUT
+        echo "head_repo=$(jq -r '.head_repo // ""' strands-parsed-input.json)" >> $GITHUB_OUTPUT
 
     # Push code changes before running write commands in case we need to create a pull request
     # Pull requests cannot be created if a branch has no diff with main, so push changes first, then create pr
-    - name: Log if ref equals main
+    - name: Log if ref equals main or is fork PR
       shell: bash
       run: |
         if [ "${{ steps.read-input.outputs.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
           echo "🚫 Ref is default - skipping push operations to prevent direct commits to default branch"
+        elif [ -n "${{ steps.read-input.outputs.head_repo }}" ]; then
+          echo "🚫 Fork PR detected - skipping push operations (no write access to fork)"
         else
           echo "✅ Ref is '${{ steps.read-input.outputs.ref }}' - push operations will proceed"
         fi
     
     - name: Download repository state artifact
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == ''
       uses: actions/download-artifact@v4
       with:
         name: repository-state
@@ -36,7 +39,7 @@ runs:
       continue-on-error: true
 
     - name: Apply Artifact and Push changes
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == ''
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION

The /strands commands fails on PRs from forks because the `head.ref` doesn't detect the fork. The changes in this PR detect fork PRs by using `pr.data.head.repo.full_name`. This allows strands commands such as `/strands review` to work 
