### PR TITLE
fix: ensure finalize step in gh wf succeeds on no issue_id

### DIFF
--- a/strands-command/actions/strands-finalize/action.yml
+++ b/strands-command/actions/strands-finalize/action.yml
@@ -157,20 +157,18 @@ runs:
         fi
 
     - name: Remove strands-running label
-      if: always()
+      if: always() && steps.read-input.outputs.issue_id != ''
       uses: actions/github-script@v8
       with:
         github-token: ${{ github.token }}
         script: |
-          if ('${{ steps.read-input.outputs.issue_id }}') {
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ steps.read-input.outputs.issue_id }},
-                name: 'strands-running'
-              });
-            } catch (error) {
-              console.log('Label removal failed (may not exist):', error.message);
-            }
+          try {
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.read-input.outputs.issue_id }},
+              name: 'strands-running'
+            });
+          } catch (error) {
+            console.log('Label removal failed (may not exist):', error.message);
           }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When the workflow runs without an associated issue (manual dispatch, push trigger, etc.), the label removal step generates invalid JavaScript: `issue_number: ,  // Missing value causes SyntaxError`. In this PR we move the empty check from inside the JavaScript to the step's if condition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
