### PR TITLE
feat: add explicit agent_type field to eval runs and dashboard

### DIFF
--- a/cdk-evals/dashboard/src/context/EvaluationContext.tsx
+++ b/cdk-evals/dashboard/src/context/EvaluationContext.tsx
@@ -31,21 +31,27 @@ export interface RunsIndex {
   runs: RunIndexEntry[];
 }
 
-// Agent type inference from run_id
+// Agent type inference from run_id (fallback for runs without explicit agent_type)
 export function inferAgentType(runId: string, agentType?: string): string {
   if (agentType) return agentType;
-  if (runId.startsWith("release_notes_")) return "release-notes";
-  if (runId.startsWith("run_")) return "github-issues";
+  if (runId.startsWith("release_notes_")) return "release_notes";
+  if (runId.startsWith("github_issue_")) return "github_issue";
+  if (runId.startsWith("reviewer_")) return "reviewer";
+  if (runId.startsWith("implementer_")) return "implementer";
   return "unknown";
 }
 
 // Get display name for agent type
 export function getAgentTypeDisplayName(agentType: string): string {
   switch (agentType) {
-    case "release-notes":
+    case "release_notes":
       return "Release Notes Agent";
-    case "github-issues":
+    case "github_issue":
       return "GitHub Issues Agent";
+    case "reviewer":
+      return "Reviewer Agent";
+    case "implementer":
+      return "Implementer Agent";
     default:
       return agentType;
   }

--- a/cdk-evals/lambda/eval-runner/handler.py
+++ b/cdk-evals/lambda/eval-runner/handler.py
@@ -94,7 +94,8 @@ def run_session_evaluation(session_id: str, eval_type: str):
         reports, 
         experiment, 
         run_id_prefix=eval_type,
-        source="lambda_sqs_trigger"
+        source="lambda_sqs_trigger",
+        agent_type=eval_type,
     )
 
     return {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request introduces enhancements to agent type handling and filtering for evaluation runs, enabling more precise identification and display of agent types in both the backend and dashboard. The changes include propagating agent type information through the S3 export and indexing process, updating inference logic, and improving display names.

Agent type handling and propagation:

* Added `agent_type` as a parameter and manifest field in the `export_reports_to_s3` function, ensuring agent type is recorded and available for dashboard filtering. 
* Updated the `_update_runs_index` function to accept and store `agent_type` for each run, improving backend support for agent type filtering. 
* Modified the `task` function in `handler.py` to pass `agent_type` when exporting reports, ensuring correct propagation from the evaluation trigger.

Dashboard agent type inference and display:

* Improved the `inferAgentType` function in `EvaluationContext.tsx` to handle new agent type prefixes and updated naming conventions, providing more accurate fallback inference.
* Enhanced the `getAgentTypeDisplayName` function to support new agent types and updated display names for consistency and clarity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
