### PR TITLE
Fix: Prevent cross-language convention contamination in code reviews

### DIFF
--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -81,7 +81,8 @@ If the PR introduces or modifies public APIs, evaluate the API design from a cus
 Examine the code for quality, readability, and maintainability issues.
 
 **Constraints:**
-- You MUST check for language-specific best practices as defined in repository guidelines
+- You MUST identify the programming language of each file being reviewed
+- You MUST check for language-specific best practices as defined in repository guidelines, ensuring conventions match the file's language (e.g., do not apply Python conventions to TypeScript)
 - You MUST verify code is readable with clear variable/function names and logical structure
 - You MUST check that code is maintainable with modular design and loose coupling
 - You MUST check for code complexity and suggest simplifications


### PR DESCRIPTION
*Issue #, if available:*

In my previous TS PR, review agent suggested using pythons style naming instead of TS style, example: https://github.com/strands-agents/sdk-typescript/pull/520#discussion_r2795576224


*Description of changes:*

Added explicit language awareness to section 3.3 (Code Quality Review):

Agent must identify the programming language of each file

Agent must ensure conventions match the file's language

Added explicit example: "do not apply Python conventions to TypeScript"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
