### PR TITLE
fix: correct output reference for approval-env in integration 

### DIFF
--- a/strands-command/README.md
+++ b/strands-command/README.md
@@ -87,7 +87,7 @@ jobs:
     permissions: read-all
     runs-on: ubuntu-latest
     outputs:
-      approval-env: ${{ steps.auth.outputs.result }}
+      approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
       - name: Check Authorization
         id: auth


### PR DESCRIPTION



*Issue #, if available:*

*Description of changes:*
Changed `steps.auth.outputs.result` to `steps.auth.outputs.approval-env` to correctly reference the named output from the auth step.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
