### PR TITLE
refactor: replace custom Langfuse mapper with strands-evals LangfuseProvider

### DIFF
--- a/cdk-evals/README.md
+++ b/cdk-evals/README.md
@@ -22,6 +22,7 @@ AWS CDK infrastructure for the Strands Evals Dashboard and Evaluation Pipeline.
 2. **AWS CLI** configured with credentials
 3. **AWS CDK CLI**: `npm install -g aws-cdk`
 4. **Docker** (required for Python Lambda bundling - must be running during deployment)
+   - If using **Podman** instead of Docker: `export CDK_DOCKER=podman`
 
 ## Setup
 

--- a/cdk-evals/lambda/eval-runner/handler.py
+++ b/cdk-evals/lambda/eval-runner/handler.py
@@ -39,8 +39,8 @@ setup_environment()
 
 # Now import evaluation modules after environment is set
 from strands_evals import Case, Experiment
+from strands_evals.providers import LangfuseProvider
 
-from mappers import LangfuseSessionMapper, SessionMapper
 from s3_export import export_reports_to_s3
 from eval_configs import get_eval_config
 
@@ -49,21 +49,17 @@ def run_session_evaluation(session_id: str, eval_type: str):
     """Run evaluation on a single session by ID."""
     logger.info(f"Running session evaluation: session_id={session_id}, eval_type={eval_type}")
     
-    mapper = LangfuseSessionMapper()
+    provider = LangfuseProvider()
     try:
-        session = mapper.get_session(session_id)
+        eval_data = provider.get_evaluation_data(session_id)
     except Exception as e:
         logger.error(f"Error fetching session: {e}")
         raise
     
-    user_input, agent_output = SessionMapper.extract_input_output(session)
-    if not agent_output:
-        raise ValueError("Could not extract agent output from session")
-    
     case_name = f"Session {session_id}"
     case_data = {
         "name": case_name,
-        "input": user_input,
+        "input": session_id,
         "expected_output": "",
         "expected_trajectory": [],
         "metadata": {
@@ -81,10 +77,7 @@ def run_session_evaluation(session_id: str, eval_type: str):
     logger.info(f"Evaluators: {[e.get_type_name() for e in experiment.evaluators]}")
     
     def task(case: Case) -> dict:
-        return {
-            "output": agent_output,
-            "trajectory": session,
-        }
+        return eval_data
     
     logger.info("Running evaluations...")
     reports = experiment.run_evaluations(task)

--- a/cdk-evals/lambda/eval-runner/requirements.txt
+++ b/cdk-evals/lambda/eval-runner/requirements.txt
@@ -1,14 +1,2 @@
-# Core evaluation framework
-strands-agents-evals>=0.1.1
-
-# Langfuse for fetching sessions
-langfuse>=3.0.0
-
-# OpenTelemetry SDK (required for package metadata lookup)
-opentelemetry-sdk>=1.20.0
-
-# AWS SDK (included in Lambda runtime but pinning for consistency)
-boto3>=1.35.0
-
-# Environment variable support
-python-dotenv>=1.0.0
+# Core evaluation framework with Langfuse provider support
+strands-agents-evals[langfuse]>=0.1.8


### PR DESCRIPTION


*Description of changes:*
Replace custom Langfuse mapper with strands-evals LangfuseProvider

- Use LangfuseProvider from strands_evals.providers instead of custom LangfuseSessionMapper, simplifying session fetching and data extraction
- Consolidate dependencies to strands-agents-evals[langfuse]>=0.1.8, removing individually pinned packages
- Add Podman configuration note to README prerequisites


*Tested*
- You can see a successful run by looking in our dashboard or looking at the run output in our S3 bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
