### PR TITLE
feat: add documentation check to task reviewer

### DIFF
--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -113,6 +113,18 @@ Check documentation completeness and quality.
 - You MUST verify that README.md updates are included if needed
 - You MUST check that development documentation is updated if patterns changed
 
+#### 3.6 Documentation PR Check
+
+Verify that a corresponding documentation PR exists in the [strands-agents/docs](https://github.com/strands-agents/docs) repository, or that the author has provided a valid justification for why documentation updates are not needed.
+
+**Constraints:**
+- You MUST check the PR description for a "Documentation PR" section containing a link to a PR in the `strands-agents/docs` repository
+- You MUST verify the linked documentation PR is a valid URL pointing to `https://github.com/strands-agents/docs/pull/...`
+- If no documentation PR is linked, you MUST check whether the PR description contains a clear and valid explanation under a "Documentation PR" heading for why documentation updates are not required (e.g., internal refactor with no public API changes, test-only changes, CI/config changes)
+- If neither a documentation PR link nor a valid justification is present, you MUST NOT approve the PR because documentation coverage is required for all user-facing changes
+- You MUST post a review comment requesting the author to add a "Documentation PR" section to the PR description containing either a link to a documentation PR in [strands-agents/docs](https://github.com/strands-agents/docs) or a clear explanation of why documentation updates are not necessary
+- You MUST treat a missing or inadequate documentation PR justification as a blocking issue (Request Changes)
+
 ### 4. Generate Review Comments
 
 Create specific, actionable review comments for identified issues.
@@ -170,6 +182,7 @@ Provide a concise overall summary of the review.
 **Constraints:**
 - You MUST create a pull request review using GitHub's review feature
 - You MUST provide an overall assessment (Approve, Request Changes, Comment)
+- You MUST NOT approve the PR if the Documentation PR Check (step 3.6) has failed
 - You MUST keep the summary concise, informative, and easy to read
 - You MUST NOT repeat information already covered in inline comments
 - You MUST focus on high-level themes and patterns, not individual issues

--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -104,7 +104,7 @@ Analyze the test coverage and quality of tests.
 
 #### 3.5 Documentation Review
 
-Check documentation completeness and quality.
+Check documentation completeness, quality, and that a corresponding documentation PR exists.
 
 **Constraints:**
 - You MUST verify documentation exists for all public APIs as required by repository guidelines
@@ -112,18 +112,12 @@ Check documentation completeness and quality.
 - You MAY suggest examples for complex APIs
 - You MUST verify that README.md updates are included if needed
 - You MUST check that development documentation is updated if patterns changed
-
-#### 3.6 Documentation PR Check
-
-Verify that a corresponding documentation PR exists in the [strands-agents/docs](https://github.com/strands-agents/docs) repository, or that the author has provided a valid justification for why documentation updates are not needed.
-
-**Constraints:**
-- You MUST check the PR description for a "Documentation PR" section containing a link to a PR in the `strands-agents/docs` repository
-- You MUST verify the linked documentation PR is a valid URL pointing to `https://github.com/strands-agents/docs/pull/...`
-- If no documentation PR is linked, you MUST check whether the PR description contains a clear and valid explanation under a "Documentation PR" heading for why documentation updates are not required (e.g., internal refactor with no public API changes, test-only changes, CI/config changes)
-- If neither a documentation PR link nor a valid justification is present, you MUST NOT approve the PR because documentation coverage is required for all user-facing changes
-- You MUST post a review comment requesting the author to add a "Documentation PR" section to the PR description containing either a link to a documentation PR in [strands-agents/docs](https://github.com/strands-agents/docs) or a clear explanation of why documentation updates are not necessary
-- You MUST treat a missing or inadequate documentation PR justification as a blocking issue (Request Changes)
+- You MUST check the PR description for a "Documentation PR" section
+- You MUST verify any linked documentation PR points to `https://github.com/strands-agents/docs/pull/...`
+- If no documentation PR is linked, you MUST check for a justification under the "Documentation PR" heading explaining why updates are not required
+- Valid justifications include: internal refactor with no public API changes, test-only changes, CI/config changes
+- If neither a valid documentation PR link nor a justification is present, you MUST treat this as a blocking issue (Request Changes)
+- You MUST post a review comment requesting the author add a "Documentation PR" section with either a link or a justification
 
 ### 4. Generate Review Comments
 
@@ -182,7 +176,7 @@ Provide a concise overall summary of the review.
 **Constraints:**
 - You MUST create a pull request review using GitHub's review feature
 - You MUST provide an overall assessment (Approve, Request Changes, Comment)
-- You MUST NOT approve the PR if the Documentation PR Check (step 3.6) has failed
+- You MUST NOT approve the PR if the Documentation PR Check (step 3.5) has failed
 - You MUST keep the summary concise, informative, and easy to read
 - You MUST NOT repeat information already covered in inline comments
 - You MUST focus on high-level themes and patterns, not individual issues


### PR DESCRIPTION
*Issue #, if available:*
Included in: https://github.com/strands-agents/sdk-python/issues/1815

*Description of changes:*
Adds a Documentation PR Check to the Task Reviewer SOP, requiring reviewers to verify that a corresponding docs PR exists in strands-agents/docs or that the author provides a valid justification for its absence. The new constraints are merged into the existing Documentation Review section (3.5) and treated as a blocking review gate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
