### PR TITLE
feat: add AI-powered insights page with SOP-based evaluation analysis

### DIFF
--- a/cdk-evals/dashboard/src/App.tsx
+++ b/cdk-evals/dashboard/src/App.tsx
@@ -8,6 +8,7 @@ import TestCasesPage from "./pages/TestCasesPage";
 import ScoreTrendsPage from "./pages/ScoreTrendsPage";
 import AgentProgressPage from "./pages/AgentProgressPage";
 import SettingsPage from "./pages/SettingsPage";
+import InsightsPage from "./pages/InsightsPage";
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
           <Route path="/cases" element={<TestCasesPage />} />
           <Route path="/trends" element={<ScoreTrendsPage />} />
           <Route path="/agent-progress" element={<AgentProgressPage />} />
+          <Route path="/insights" element={<InsightsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </EvaluationProvider>

--- a/cdk-evals/dashboard/src/components/Layout.tsx
+++ b/cdk-evals/dashboard/src/components/Layout.tsx
@@ -28,6 +28,7 @@ const ROUTE_TITLES: Record<string, string> = {
   "/trends": "Score Trends",
   "/cases": "Test Cases",
   "/agent-progress": "Agent Progress",
+  "/insights": "Insights",
   "/settings": "Settings",
 };
 
@@ -69,6 +70,7 @@ export default function Layout({ children, title, description, breadcrumbs }: La
       type: "section" as const,
       defaultExpanded: true,
       items: [
+        { href: "/insights", text: "Insights", type: "link" as const },
         { href: "/agent-progress", text: "Agent Progress", type: "link" as const },
         { href: "/trends", text: "Score Trends", type: "link" as const },
         { href: "/cases", text: "Test Cases", type: "link" as const },

--- a/cdk-evals/dashboard/src/context/EvaluationContext.tsx
+++ b/cdk-evals/dashboard/src/context/EvaluationContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useCallback, useEffect } from "rea
 import type { ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
 import type { SelectProps } from "@cloudscape-design/components/select";
-import type { EvaluationReport, Session } from "../types/evaluation";
+import type { EvaluationReport, InsightsData, Session } from "../types/evaluation";
 
 export interface EvaluatorData {
   name: string;
@@ -121,6 +121,7 @@ export function getStatusType(score: number): "success" | "warning" | "error" {
 interface EvaluationContextType {
   evaluators: EvaluatorData[];
   manifest: Manifest | null;
+  insights: InsightsData | null;
   loading: boolean;
   error: string | null;
   setError: (error: string | null) => void;
@@ -151,6 +152,7 @@ export function EvaluationProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedCase, setSelectedCase] = useState<number>(0);
+  const [insights, setInsights] = useState<InsightsData | null>(null);
   const [runsIndex, setRunsIndex] = useState<RunsIndex | null>(null);
   const [selectedRun, setSelectedRun] = useState<SelectProps.Option | null>(null);
 
@@ -192,6 +194,18 @@ export function EvaluationProvider({ children }: { children: ReactNode }) {
       }
       setEvaluators(evaluatorData);
       setSelectedCase(0);
+
+      // Load insights if available
+      try {
+        const insightsRes = await fetch(`/runs/${runId}/insights.json`);
+        if (insightsRes.ok) {
+          setInsights(await insightsRes.json());
+        } else {
+          setInsights(null);
+        }
+      } catch {
+        setInsights(null);
+      }
     } catch (err) {
       setError(`Failed to load run: ${err}`);
     }
@@ -307,6 +321,7 @@ export function EvaluationProvider({ children }: { children: ReactNode }) {
   const value: EvaluationContextType = {
     evaluators,
     manifest,
+    insights,
     loading,
     error,
     setError,

--- a/cdk-evals/dashboard/src/pages/DashboardPage.tsx
+++ b/cdk-evals/dashboard/src/pages/DashboardPage.tsx
@@ -17,7 +17,7 @@ import EvaluatorScoresTable from "../components/EvaluatorScoresTable";
 import ConversationViewer from "../components/ConversationViewer";
 import RunComparisonModal from "../components/RunComparisonModal";
 import { isSession } from "../types/evaluation";
-import type { EvaluationReport } from "../types/evaluation";
+import type { EvaluationReport, InsightsData } from "../types/evaluation";
 import {
   useEvaluation,
   getScoreColor,
@@ -336,14 +336,90 @@ function TestResultsContainer({
   );
 }
 
+function InsightsTabContent({ insights }: { insights: InsightsData }) {
+  return (
+    <SpaceBetween size="m">
+      <Box>{insights.summary}</Box>
+
+      <ColumnLayout columns={3}>
+        <Box>
+          <Box variant="awsui-key-label">Weakest Evaluator</Box>
+          <Box>{insights.score_analysis.lowest_scoring_evaluator}</Box>
+        </Box>
+        <Box>
+          <Box variant="awsui-key-label">Score</Box>
+          <StatusIndicator type={getStatusType(insights.score_analysis.lowest_score)}>
+            {(insights.score_analysis.lowest_score * 100).toFixed(0)}%
+          </StatusIndicator>
+        </Box>
+        <Box>
+          <Box variant="awsui-key-label">Primary Weakness</Box>
+          <Box>{insights.score_analysis.primary_weakness}</Box>
+        </Box>
+      </ColumnLayout>
+
+      {insights.insights.map((insight, idx) => (
+        <Container
+          key={idx}
+          header={
+            <Header variant="h3">
+              <SpaceBetween direction="horizontal" size="xs">
+                <StatusIndicator
+                  type={
+                    insight.severity === "high"
+                      ? "error"
+                      : insight.severity === "medium"
+                        ? "warning"
+                        : "info"
+                  }
+                >
+                  {insight.severity}
+                </StatusIndicator>
+                <span>{insight.title}</span>
+              </SpaceBetween>
+            </Header>
+          }
+        >
+          <SpaceBetween size="s">
+            <Box>{insight.description}</Box>
+            {insight.suggested_change && (
+              <Box>
+                <Box variant="awsui-key-label">
+                  Suggested Change{insight.sop_section ? ` (${insight.sop_section})` : ""}
+                </Box>
+                <pre
+                  style={{
+                    whiteSpace: "pre-wrap",
+                    fontFamily: "monospace",
+                    fontSize: "13px",
+                    background: "#f0fdf4",
+                    padding: "12px",
+                    borderRadius: "4px",
+                    border: "1px solid #bbf7d0",
+                    margin: 0,
+                  }}
+                >
+                  {insight.suggested_change}
+                </pre>
+              </Box>
+            )}
+          </SpaceBetween>
+        </Container>
+      ))}
+    </SpaceBetween>
+  );
+}
+
 function CaseDetailContainer({
   evaluators,
   selectedCase,
   onCaseChange,
+  insights,
 }: {
   evaluators: EvaluatorData[];
   selectedCase: number;
   onCaseChange: (index: number) => void;
+  insights: InsightsData | null;
 }) {
   if (evaluators.length === 0) {
     return (
@@ -514,6 +590,15 @@ function CaseDetailContainer({
                 },
               ]
             : []),
+          ...(insights
+            ? [
+                {
+                  id: "insights",
+                  label: "Insights",
+                  content: <InsightsTabContent insights={insights} />,
+                },
+              ]
+            : []),
         ]}
       />
     </Container>
@@ -521,7 +606,7 @@ function CaseDetailContainer({
 }
 
 export default function DashboardPage() {
-  const { evaluators, manifest, selectedCase, setSelectedCase, runsIndex, selectedRun } = useEvaluation();
+  const { evaluators, manifest, insights, selectedCase, setSelectedCase, runsIndex, selectedRun } = useEvaluation();
   const [showOnlyFailed, setShowOnlyFailed] = useState(false);
   const [compareModalVisible, setCompareModalVisible] = useState(false);
   const testResultsRef = useRef<HTMLDivElement>(null);
@@ -642,6 +727,7 @@ export default function DashboardPage() {
           evaluators={evaluators}
           selectedCase={selectedCase}
           onCaseChange={setSelectedCase}
+          insights={insights}
         />
         <div ref={testResultsRef}>
           <TestResultsContainer

--- a/cdk-evals/dashboard/src/pages/InsightsPage.tsx
+++ b/cdk-evals/dashboard/src/pages/InsightsPage.tsx
@@ -1,0 +1,143 @@
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Box from "@cloudscape-design/components/box";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import ExpandableSection from "@cloudscape-design/components/expandable-section";
+import Badge from "@cloudscape-design/components/badge";
+import Layout from "../components/Layout";
+import { useEvaluation, getAgentTypeDisplayName } from "../context/EvaluationContext";
+import type { Insight } from "../types/evaluation";
+
+function getSeverityIndicator(severity: Insight["severity"]) {
+  switch (severity) {
+    case "high":
+      return <StatusIndicator type="error">High</StatusIndicator>;
+    case "medium":
+      return <StatusIndicator type="warning">Medium</StatusIndicator>;
+    case "low":
+      return <StatusIndicator type="info">Low</StatusIndicator>;
+  }
+}
+
+function getCategoryLabel(category: Insight["category"]) {
+  switch (category) {
+    case "sop_improvement":
+      return "SOP Improvement";
+    case "tool_usage":
+      return "Tool Usage";
+    case "behavior_pattern":
+      return "Behavior Pattern";
+    case "efficiency":
+      return "Efficiency";
+  }
+}
+
+export default function InsightsPage() {
+  const { insights, manifest } = useEvaluation();
+
+  if (!insights) {
+    return (
+      <Layout title="Insights" description="AI-generated improvement recommendations">
+        <Container>
+          <Box color="text-status-inactive" textAlign="center" padding="xl">
+            No insights available for this run. Insights are generated automatically after each evaluation.
+          </Box>
+        </Container>
+      </Layout>
+    );
+  }
+
+  const agentType = getAgentTypeDisplayName(insights.agent_type);
+
+  return (
+    <Layout title="Insights" description="AI-generated improvement recommendations">
+      <SpaceBetween size="l">
+        {/* Summary */}
+        <Container
+          header={
+            <Header variant="h2" description={`${agentType} — ${manifest?.run_id || insights.run_id}`}>
+              Analysis Summary
+            </Header>
+          }
+        >
+          <SpaceBetween size="m">
+            <Box fontSize="heading-m">{insights.summary}</Box>
+            <ColumnLayout columns={3}>
+              <div>
+                <Box variant="awsui-key-label">Weakest Evaluator</Box>
+                <Box fontSize="heading-s">{insights.score_analysis.lowest_scoring_evaluator}</Box>
+              </div>
+              <div>
+                <Box variant="awsui-key-label">Lowest Score</Box>
+                <Box fontSize="heading-s">{(insights.score_analysis.lowest_score * 100).toFixed(0)}%</Box>
+              </div>
+              <div>
+                <Box variant="awsui-key-label">Primary Weakness</Box>
+                <Box fontSize="heading-s">{insights.score_analysis.primary_weakness}</Box>
+              </div>
+            </ColumnLayout>
+          </SpaceBetween>
+        </Container>
+
+        {/* Insights List */}
+        <Container
+          header={
+            <Header variant="h2" counter={`(${insights.insights.length})`}>
+              Improvement Recommendations
+            </Header>
+          }
+        >
+          <SpaceBetween size="m">
+            {insights.insights.map((insight, idx) => (
+              <Container
+                key={idx}
+                header={
+                  <Header
+                    variant="h3"
+                    actions={
+                      <SpaceBetween direction="horizontal" size="xs">
+                        <Badge color={insight.severity === "high" ? "red" : insight.severity === "medium" ? "blue" : "grey"}>
+                          {getCategoryLabel(insight.category)}
+                        </Badge>
+                        {getSeverityIndicator(insight.severity)}
+                      </SpaceBetween>
+                    }
+                  >
+                    {insight.title}
+                  </Header>
+                }
+              >
+                <SpaceBetween size="s">
+                  <Box>{insight.description}</Box>
+
+                  {(insight.sop_section || insight.suggested_change) && (
+                    <ExpandableSection headerText="Suggested Change" variant="footer">
+                      <SpaceBetween size="s">
+                        {insight.sop_section && (
+                          <div>
+                            <Box variant="awsui-key-label">SOP Section</Box>
+                            <Box><code>{insight.sop_section}</code></Box>
+                          </div>
+                        )}
+                        <div>
+                          <Box variant="awsui-key-label">Recommended Change</Box>
+                          <Box>
+                            <pre style={{ whiteSpace: "pre-wrap", margin: 0, fontFamily: "inherit" }}>
+                              {insight.suggested_change}
+                            </pre>
+                          </Box>
+                        </div>
+                      </SpaceBetween>
+                    </ExpandableSection>
+                  )}
+                </SpaceBetween>
+              </Container>
+            ))}
+          </SpaceBetween>
+        </Container>
+      </SpaceBetween>
+    </Layout>
+  );
+}

--- a/cdk-evals/dashboard/src/types/evaluation.ts
+++ b/cdk-evals/dashboard/src/types/evaluation.ts
@@ -138,6 +138,29 @@ export interface EvaluatorResult {
   report: EvaluationReport;
 }
 
+// Insights types
+export interface Insight {
+  category: "sop_improvement" | "tool_usage" | "behavior_pattern" | "efficiency";
+  severity: "high" | "medium" | "low";
+  title: string;
+  description: string;
+  sop_section: string | null;
+  suggested_change: string;
+}
+
+export interface InsightsData {
+  run_id: string;
+  agent_type: string;
+  timestamp: string;
+  summary: string;
+  insights: Insight[];
+  score_analysis: {
+    lowest_scoring_evaluator: string;
+    lowest_score: number;
+    primary_weakness: string;
+  };
+}
+
 // Helper type guards
 export function isSession(trajectory: Session | string[] | undefined): trajectory is Session {
   return trajectory !== undefined && 

--- a/cdk-evals/lambda/eval-runner/eval_configs.py
+++ b/cdk-evals/lambda/eval-runner/eval_configs.py
@@ -3,8 +3,8 @@
 Maps eval_type strings to their evaluator configurations.
 """
 
-from dataclasses import dataclass
-from typing import Type
+from dataclasses import dataclass, field
+from typing import Optional, Type
 from strands_evals.evaluators import (
     Evaluator,
     HelpfulnessEvaluator,
@@ -24,6 +24,7 @@ class EvalConfig:
     """Configuration for a specific evaluation type."""
     evaluators: list[Type[Evaluator]]
     description: str
+    sop_file: Optional[str] = None
 
 
 EVAL_CONFIGS: dict[str, EvalConfig] = {
@@ -35,7 +36,8 @@ EVAL_CONFIGS: dict[str, EvalConfig] = {
             TurnEfficiencyEvaluator,
             ConciseResponseEvaluator,
         ],
-        description="Evaluates github issue resolution agents"
+        description="Evaluates github issue resolution agents",
+        sop_file="task-implementer.sop.md",
     ),
     "release_notes": EvalConfig(
         evaluators=[
@@ -43,7 +45,8 @@ EVAL_CONFIGS: dict[str, EvalConfig] = {
             HelpfulnessEvaluator,
             ConciseResponseEvaluator,
         ],
-        description="Evaluates release notes generation"
+        description="Evaluates release notes generation",
+        sop_file="task-release-notes.sop.md",
     ),
     "reviewer": EvalConfig(
         evaluators=[
@@ -52,14 +55,16 @@ EVAL_CONFIGS: dict[str, EvalConfig] = {
             ConciseResponseEvaluator,
             TurnEfficiencyEvaluator,
         ],
-        description="Evaluates code review agents"
+        description="Evaluates code review agents",
+        sop_file="task-reviewer.sop.md",
     ),
     "implementer": EvalConfig(
         evaluators=[
             ToolSelectionAccuracyEvaluator,
             TurnEfficiencyEvaluator,
         ],
-        description="Evaluates implementation agents"
+        description="Evaluates implementation agents",
+        sop_file="task-implementer.sop.md",
     ),
 }
 

--- a/cdk-evals/lambda/eval-runner/handler.py
+++ b/cdk-evals/lambda/eval-runner/handler.py
@@ -41,8 +41,9 @@ setup_environment()
 from strands_evals import Case, Experiment
 from strands_evals.providers import LangfuseProvider
 
-from s3_export import export_reports_to_s3
+from s3_export import export_reports_to_s3, export_insights_to_s3
 from eval_configs import get_eval_config
+from insights_generator import generate_insights
 
 
 def run_session_evaluation(session_id: str, eval_type: str):
@@ -83,13 +84,21 @@ def run_session_evaluation(session_id: str, eval_type: str):
     reports = experiment.run_evaluations(task)
 
     # Export to S3
-    export_reports_to_s3(
-        reports, 
-        experiment, 
+    run_id = export_reports_to_s3(
+        reports,
+        experiment,
         run_id_prefix=eval_type,
         source="lambda_sqs_trigger",
         agent_type=eval_type,
     )
+
+    # Generate and export insights (non-fatal — failure doesn't affect eval results)
+    try:
+        insights = generate_insights(reports, eval_data, eval_type)
+        export_insights_to_s3(insights, run_id)
+        logger.info(f"Insights generated and exported for run {run_id}")
+    except Exception as e:
+        logger.warning(f"Insights generation failed (non-fatal): {e}", exc_info=True)
 
     return {
         "session_id": session_id,

--- a/cdk-evals/lambda/eval-runner/insights_generator.py
+++ b/cdk-evals/lambda/eval-runner/insights_generator.py
@@ -1,0 +1,261 @@
+"""Generate actionable insights from evaluation results using LLM analysis.
+
+Analyzes eval scores, reasoning, and tool usage against the agent's SOP
+to produce specific improvement recommendations.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from strands import Agent
+from strands.models import BedrockModel
+
+if TYPE_CHECKING:
+    from strands_evals.types.evaluation_report import EvaluationReport
+
+from eval_configs import get_eval_config
+
+logger = logging.getLogger(__name__)
+
+SOPS_DIR = os.path.join(os.path.dirname(__file__), "sops")
+
+INSIGHTS_SYSTEM_PROMPT = """You are an expert at analyzing AI agent evaluation results and generating actionable improvement recommendations.
+
+You analyze evaluation scores, evaluator reasoning, and tool usage patterns, then compare against the agent's Standard Operating Procedure (SOP) to identify specific, implementable improvements.
+
+Your insights must be:
+- Evidence-based: cite specific scores, reasoning, or tool patterns
+- Actionable: suggest concrete SOP wording changes or behavioral adjustments
+- Prioritized: high severity for issues causing failures, medium for inefficiencies, low for minor improvements"""
+
+INSIGHTS_USER_PROMPT_TEMPLATE = """## Agent Type: {eval_type}
+## Agent Description: {eval_description}
+
+## Current SOP (System Prompt)
+{sop_content}
+
+## Available Tools
+{available_tools}
+
+## Agent Input (Task Given)
+{agent_input}
+
+## Agent Output (Final Response)
+{agent_output}
+
+## Evaluation Results
+{eval_summaries}
+
+## Tool Usage Summary
+{trajectory_summary}
+
+## Task
+Analyze these evaluation results and generate 3-7 specific, actionable insights for improving this agent. Consider ALL aspects of the agent's configuration:
+
+1. **SOP/System Prompt**: Are instructions clear? Missing guidance? Contradictory?
+2. **Tool definitions**: Are tool descriptions adequate? Should tools be added, removed, or have their descriptions improved?
+3. **Tool usage patterns**: Is the agent using the right tools? Redundant calls? Missing tools it should use?
+4. **Behavioral patterns**: Response quality, verbosity, reasoning depth, error handling
+5. **Efficiency**: Turn count, tool call count, unnecessary steps
+
+For each insight, provide:
+1. category: one of "sop_improvement", "tool_usage", "behavior_pattern", "efficiency"
+2. severity: "high" (causing failures), "medium" (causing inefficiency), "low" (minor improvement)
+3. title: a short actionable title
+4. description: detailed description with evidence from the eval results
+5. sop_section: the specific SOP section heading to modify (or null if not SOP-related)
+6. suggested_change: exact wording to add or modify in the SOP, tool description, or agent configuration
+
+Also provide:
+- A 1-2 sentence summary of the overall analysis
+- The lowest scoring evaluator name, its score, and the primary weakness it reveals
+
+Respond with ONLY valid JSON matching this exact schema:
+{{
+  "summary": "string",
+  "insights": [
+    {{
+      "category": "string",
+      "severity": "string",
+      "title": "string",
+      "description": "string",
+      "sop_section": "string or null",
+      "suggested_change": "string"
+    }}
+  ],
+  "score_analysis": {{
+    "lowest_scoring_evaluator": "string",
+    "lowest_score": 0.0,
+    "primary_weakness": "string"
+  }}
+}}"""
+
+
+def _load_sop(eval_type: str) -> str:
+    """Load the SOP file for a given eval type."""
+    config = get_eval_config(eval_type)
+    if not config.sop_file:
+        return "(No SOP configured for this agent type)"
+    sop_path = os.path.join(SOPS_DIR, config.sop_file)
+    try:
+        with open(sop_path) as f:
+            return f.read()
+    except FileNotFoundError:
+        logger.warning(f"SOP file not found: {sop_path}")
+        return "(SOP file not available)"
+
+
+def _build_eval_summaries(
+    reports: list["EvaluationReport"],
+    evaluator_names: list[str],
+) -> str:
+    """Build a text summary of evaluation results for the prompt."""
+    lines = []
+    for report, name in zip(reports, evaluator_names):
+        lines.append(f"### {name}")
+        lines.append(f"- Overall Score: {report.overall_score:.2f}")
+        lines.append(f"- Passed: {sum(report.test_passes)}/{len(report.test_passes)}")
+        if report.reasons:
+            lines.append(f"- Reasoning: {report.reasons[0][:1000]}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_trajectory_summary(eval_data: dict) -> str:
+    """Build a summary of tool usage from the evaluation data."""
+    session = eval_data.get("actual_trajectory")
+    if not session:
+        return "(No trajectory data available)"
+
+    tool_counts: dict[str, int] = {}
+    if isinstance(session, dict) and "traces" in session:
+        for trace in session["traces"]:
+            for span in trace.get("spans", []):
+                if span.get("span_type") == "execute_tool":
+                    tool_name = span.get("tool_call", {}).get("name", "unknown")
+                    tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+    elif isinstance(session, list):
+        for tool_name in session:
+            tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+
+    if not tool_counts:
+        return "(No tool usage detected)"
+
+    lines = [f"- {name}: {count}x" for name, count in sorted(tool_counts.items(), key=lambda x: -x[1])]
+    lines.insert(0, f"Total tool calls: {sum(tool_counts.values())}")
+    return "\n".join(lines)
+
+
+def _extract_available_tools(eval_data: dict) -> str:
+    """Extract tool definitions from AgentInvocationSpan in the trace data."""
+    session = eval_data.get("actual_trajectory")
+    if not isinstance(session, dict) or "traces" not in session:
+        return "(No tool definitions available)"
+
+    tools: dict[str, str] = {}
+    for trace in session["traces"]:
+        for span in trace.get("spans", []):
+            if span.get("span_type") == "invoke_agent":
+                for tool in span.get("available_tools", []):
+                    name = tool.get("name", "unknown")
+                    desc = tool.get("description", "")
+                    if name not in tools:
+                        tools[name] = desc
+
+    if not tools:
+        return "(No tool definitions found in traces)"
+
+    lines = []
+    for name, desc in sorted(tools.items()):
+        if desc:
+            lines.append(f"- **{name}**: {desc[:200]}")
+        else:
+            lines.append(f"- **{name}**")
+    return "\n".join(lines)
+
+
+def _extract_agent_io(eval_data: dict) -> tuple[str, str]:
+    """Extract the agent's input (user_prompt) and output (agent_response) from traces."""
+    session = eval_data.get("actual_trajectory")
+    if not isinstance(session, dict) or "traces" not in session:
+        return "(No input available)", "(No output available)"
+
+    user_prompt = ""
+    agent_response = ""
+    for trace in session["traces"]:
+        for span in trace.get("spans", []):
+            if span.get("span_type") == "invoke_agent":
+                if not user_prompt:
+                    user_prompt = span.get("user_prompt", "")
+                # Take the last agent response
+                agent_response = span.get("agent_response", "")
+
+    return (
+        user_prompt[:2000] if user_prompt else "(No input available)",
+        agent_response[:2000] if agent_response else "(No output available)",
+    )
+
+
+def _create_insights_agent() -> Agent:
+    """Create a Strands Agent configured for insights generation."""
+    return Agent(system_prompt=INSIGHTS_SYSTEM_PROMPT)
+
+
+def generate_insights(
+    reports: list["EvaluationReport"],
+    eval_data: dict,
+    eval_type: str,
+) -> dict:
+    """Generate actionable insights from evaluation results.
+
+    Args:
+        reports: List of EvaluationReport objects from experiment.run_evaluations()
+        eval_data: The evaluation data dict (contains actual_trajectory, etc.)
+        eval_type: The evaluation type (e.g., "reviewer", "github_issue")
+
+    Returns:
+        Insights dict ready for S3 export
+    """
+    config = get_eval_config(eval_type)
+    evaluator_names = [e.__name__ for e in config.evaluators]
+
+    sop_content = _load_sop(eval_type)
+    eval_summaries = _build_eval_summaries(reports, evaluator_names)
+    trajectory_summary = _build_trajectory_summary(eval_data)
+    available_tools = _extract_available_tools(eval_data)
+    agent_input, agent_output = _extract_agent_io(eval_data)
+
+    user_prompt = INSIGHTS_USER_PROMPT_TEMPLATE.format(
+        eval_type=eval_type,
+        eval_description=config.description,
+        sop_content=sop_content,
+        available_tools=available_tools,
+        agent_input=agent_input,
+        agent_output=agent_output,
+        eval_summaries=eval_summaries,
+        trajectory_summary=trajectory_summary,
+    )
+
+    logger.info("Invoking insights agent...")
+    agent = _create_insights_agent()
+    result = agent(user_prompt)
+    response_text = str(result)
+
+    # Parse JSON from response (handle markdown code fences)
+    json_text = response_text.strip()
+    if json_text.startswith("```"):
+        json_text = json_text.split("\n", 1)[1]
+        json_text = json_text.rsplit("```", 1)[0]
+
+    insights_data = json.loads(json_text)
+
+    # Add metadata
+    insights_data["run_id"] = ""  # Will be set by caller
+    insights_data["agent_type"] = eval_type
+    insights_data["timestamp"] = datetime.now().isoformat()
+
+    logger.info(f"Generated {len(insights_data.get('insights', []))} insights")
+    return insights_data

--- a/cdk-evals/lambda/eval-runner/s3_export.py
+++ b/cdk-evals/lambda/eval-runner/s3_export.py
@@ -101,6 +101,44 @@ def export_reports_to_s3(
     return run_id
 
 
+def export_insights_to_s3(insights: dict, run_id: str) -> None:
+    """Export insights JSON to S3 alongside eval results.
+
+    Args:
+        insights: Insights dict from generate_insights()
+        run_id: The run ID to export insights for
+    """
+    s3 = boto3.client("s3", region_name=REGION)
+
+    insights["run_id"] = run_id
+
+    # Write insights.json
+    insights_key = f"runs/{run_id}/insights.json"
+    logger.info(f"  Uploading insights.json for run {run_id}")
+    s3.put_object(
+        Bucket=BUCKET_NAME,
+        Key=insights_key,
+        Body=json.dumps(insights, indent=2),
+        ContentType="application/json",
+    )
+
+    # Update manifest with has_insights flag
+    manifest_key = f"runs/{run_id}/manifest.json"
+    try:
+        response = s3.get_object(Bucket=BUCKET_NAME, Key=manifest_key)
+        manifest = json.loads(response["Body"].read().decode("utf-8"))
+        manifest["has_insights"] = True
+        s3.put_object(
+            Bucket=BUCKET_NAME,
+            Key=manifest_key,
+            Body=json.dumps(manifest, indent=2),
+            ContentType="application/json",
+        )
+        logger.info("  Updated manifest.json with has_insights=true")
+    except ClientError as e:
+        logger.warning(f"Failed to update manifest with insights flag: {e}")
+
+
 def _update_runs_index(
     s3,
     run_id: str,

--- a/cdk-evals/lib/eval-pipeline-stack.ts
+++ b/cdk-evals/lib/eval-pipeline-stack.ts
@@ -67,6 +67,8 @@ export class EvalPipelineStack extends cdk.Stack {
     });
 
     // Lambda Function for running evaluations
+    const agentSopsDir = path.join(__dirname, "../../strands-command/agent-sops");
+
     this.evalFunction = new PythonFunction(this, "EvalRunnerFunction", {
       functionName: "strands-evals-runner",
       entry: path.join(__dirname, "../lambda/eval-runner"),
@@ -82,6 +84,23 @@ export class EvalPipelineStack extends cdk.Stack {
       },
       bundling: {
         assetExcludes: ['.venv'],
+        volumes: [
+          {
+            hostPath: agentSopsDir,
+            containerPath: "/tmp/agent-sops",
+          },
+        ],
+        commandHooks: {
+          beforeBundling(_inputDir: string, outputDir: string): string[] {
+            return [
+              `mkdir -p ${outputDir}/sops`,
+              `cp /tmp/agent-sops/*.sop.md ${outputDir}/sops/ 2>/dev/null || true`,
+            ];
+          },
+          afterBundling(_inputDir: string, _outputDir: string): string[] {
+            return [];
+          },
+        },
       },
     });
 


### PR DESCRIPTION
*Description of changes:*

Introduce an Insights feature that uses Bedrock to analyze evaluation results against agent Standard Operating Procedures (SOPs) and generate actionable recommendations.

- Add InsightsPage with summary cards, key findings, and recommendations
- Add SOP file support to EvalConfig for agent evaluation profiles
- Generate insights via Bedrock Claude after eval runs complete
- Upload insights.json artifacts to S3 alongside evaluation results
- Update EvaluationContext to fetch and expose insights data
- Add insights route, navigation link, and dashboard summary widget
- Define InsightsData types for findings, recommendations, and scores


This will be the step needed before we pass these insights off to an agent to make the changes to the agent.

*Issue #, if available:*
https://github.com/strands-agents/evals/issues/152

<img width="2446" height="1734" alt="image" src="https://github.com/user-attachments/assets/7cde34d8-be2a-431a-937e-60d4c74facca" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
