### PR TITLE
fix: reduce documentation review noise in task-reviewer SOP

### DIFF
--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -104,7 +104,7 @@ Analyze the test coverage and quality of tests.
 
 #### 3.5 Documentation Review
 
-Check documentation completeness, quality, and that a corresponding documentation PR exists.
+Check documentation completeness and quality. Determine whether a corresponding documentation PR is needed based on the nature of the changes — not every PR requires one.
 
 **Constraints:**
 - You MUST verify documentation exists for all public APIs as required by repository guidelines
@@ -114,10 +114,34 @@ Check documentation completeness, quality, and that a corresponding documentatio
 - You MUST check that development documentation is updated if patterns changed
 - You MUST check the PR description for a "Documentation PR" section
 - You MUST verify any linked documentation PR points to `https://github.com/strands-agents/docs/pull/...`
-- If no documentation PR is linked, you MUST check for a justification under the "Documentation PR" heading explaining why updates are not required
-- Valid justifications include: internal refactor with no public API changes, test-only changes, CI/config changes
-- If neither a valid documentation PR link nor a justification is present, you MUST treat this as a blocking issue (Request Changes)
-- You MUST post a review comment requesting the author add a "Documentation PR" section with either a link or a justification
+
+**Determining whether a documentation PR is needed:**
+
+Use judgment to answer: *"Does a user need to know about this change to use the SDK correctly?"* Apply the following criteria:
+
+- **Documentation PR REQUIRED (blocking — Request Changes if missing):**
+  - New features that add public API surface (new classes, methods, modules, or CLI commands)
+  - Breaking changes to existing public APIs (changed signatures, removed functionality, behavioral changes that break existing code)
+  - New concepts or patterns that users need to learn to use the SDK effectively
+
+- **Documentation PR SUGGESTED (non-blocking — mention in review as a suggestion):**
+  - Enhancements to existing features that change user-visible behavior
+  - New configuration options or environment variables
+  - Changes that affect documented examples or tutorials
+
+- **Documentation PR NOT NEEDED (do not request one):**
+  - Bug fixes (unless the bug revealed a gap in existing documentation)
+  - Internal refactors with no user-facing changes
+  - Test-only changes
+  - CI/config changes
+  - Performance improvements with no API changes
+  - Timeout, retry, or resilience fixes
+  - Dependency updates
+  - Code style or linting changes
+
+- If a documentation PR is required per the criteria above and neither a valid link nor a justification is present, you MUST treat this as a blocking issue (Request Changes) and post a review comment requesting the author add a "Documentation PR" section
+- If a documentation PR is only suggested, you SHOULD mention it as a non-blocking recommendation in your review
+- If the changes fall into the "not needed" category, do NOT request or suggest a documentation PR
 
 ### 4. Generate Review Comments
 
@@ -177,7 +201,7 @@ Submit the formal pull request review with a verdict and summary using the `subm
 - You MUST use the `submit_pr_review` tool to submit the review
 - You MUST set the `event` parameter to `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`
 - You MUST provide a review summary in the `body` parameter
-- You MUST NOT approve the PR if the Documentation PR Check (step 3.5) has failed
+- You MUST NOT approve the PR if a documentation PR is required per the criteria in step 3.5 and is missing
 - You MUST keep the summary concise, informative, and easy to read
 - You MUST NOT repeat information already covered in inline comments
 - You MUST focus on high-level themes and patterns, not individual issues


### PR DESCRIPTION
Documentation PRs are now only blocking for new features and breaking changes. Bug fixes, refactors, and other non-user-facing changes no longer trigger Request Changes for missing docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
