### PR TITLE
Remove submit_pr_review tool that was adding noise and blocking PRs during reviews

### DIFF
--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -179,7 +179,7 @@ Format review comments to be clear and actionable.
 
 ### 5. Post Review Comments
 
-Add inline review comments to the pull request.
+Add the review comments to the pull request.
 
 **Constraints:**
 - You MUST use the `add_pr_comment` tool for inline comments on specific lines
@@ -193,21 +193,20 @@ Add inline review comments to the pull request.
 - You MUST focus on improvements and suggestions only
 - You MUST NOT add inline comments praising good coding practices
 
-### 6. Submit Review
+### 6. Summary Review Comment
 
-Submit the formal pull request review with a verdict and summary using the `submit_pr_review` tool.
+Provide a concise overall summary of the review.
 
 **Constraints:**
-- You MUST use the `submit_pr_review` tool to submit the review
-- You MUST set the `event` parameter to `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`
-- You MUST provide a review summary in the `body` parameter
+- You MUST create a pull request review using GitHub's review feature
+- You MUST provide an overall assessment (Approve, Request Changes, Comment)
 - You MUST NOT approve the PR if a documentation PR is required per the criteria in step 3.5 and is missing
 - You MUST keep the summary concise, informative, and easy to read
 - You MUST NOT repeat information already covered in inline comments
 - You MUST focus on high-level themes and patterns, not individual issues
 - You MUST use collapsible `<details>` sections if the summary contains multiple categories or is longer than 5 lines
 - You MAY include a brief positive note at the end (1 sentence maximum)
-- You SHOULD use this format for the `body` parameter:
+- You SHOULD use this format:
   ```
   **Assessment**: [Approve/Request Changes/Comment]
   

--- a/strands-command/scripts/python/agent_runner.py
+++ b/strands-command/scripts/python/agent_runner.py
@@ -35,7 +35,6 @@ from github_tools import (
     list_issues,
     list_pull_requests,
     reply_to_review_comment,
-    submit_pr_review,
     update_issue,
     update_pull_request,
 )
@@ -175,7 +174,6 @@ def _get_all_tools() -> list[Any]:
         get_pr_review_and_comments,
         reply_to_review_comment,
         add_pr_comment,
-        submit_pr_review,
         
         # Agent tools
         notebook,

--- a/strands-command/scripts/python/github_tools.py
+++ b/strands-command/scripts/python/github_tools.py
@@ -512,42 +512,6 @@ def add_pr_comment(pr_number: int, body: str, path: str | None = None, line: int
 
 @tool
 @log_inputs
-@check_should_call_write_api_or_record
-def submit_pr_review(pr_number: int, event: str, body: str = "", repo: str | None = None) -> str:
-    """Submits a pull request review with a verdict and summary.
-
-    Args:
-        pr_number: The pull request number
-        event: The review action - "APPROVE", "REQUEST_CHANGES", or "COMMENT"
-        body: The review summary text (optional)
-        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
-
-    Returns:
-        Result of the operation
-    """
-    event = event.upper()
-    valid_events = ("APPROVE", "REQUEST_CHANGES", "COMMENT")
-    if event not in valid_events:
-        error_msg = f"Error: event must be one of {valid_events}, got '{event}'"
-        console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
-        return error_msg
-
-    data: dict[str, Any] = {"event": event}
-    if body:
-        data["body"] = body
-
-    result = _github_request("POST", f"pulls/{pr_number}/reviews", repo, data)
-    if isinstance(result, str):
-        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
-        return result
-
-    message = f"Review submitted ({event}): {result['html_url']}"
-    console.print(Panel(escape(message), title="[bold green]✅ Review Submitted", border_style="green"))
-    return message
-
-
-@tool
-@log_inputs
 def get_pr_files(pr_number: int, repo: str | None = None) -> str:
     """Gets the list of files changed in a pull request with their diffs.
 

--- a/strands-command/scripts/python/write_executor.py
+++ b/strands-command/scripts/python/write_executor.py
@@ -24,7 +24,6 @@ from github_tools import (
     update_pull_request,
     reply_to_review_comment,
     add_pr_comment,
-    submit_pr_review,
 )
 
 # Configure structured logging
@@ -46,7 +45,6 @@ def get_function_mapping() -> Dict[str, Any]:
         update_pull_request.tool_name: update_pull_request,
         reply_to_review_comment.tool_name: reply_to_review_comment,
         add_pr_comment.tool_name: add_pr_comment,
-        submit_pr_review.tool_name: submit_pr_review,
     }
 
 


### PR DESCRIPTION
In this PR, we remove the tool that allowed the review agent to submit a PR review that allowed the review agent "requested changes" or "approve" a PR. This tool highlighted two problems:
- The "Request Changes" feature didn't dismiss the review once the changes were addressed by the author.
- The "Approve" feature was a security issue because a repository wide setting would need to be enabled. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
