### PR TITLE
ci: add reusable markdown link check workflow and default config

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -31,7 +31,7 @@ jobs:
             echo "Using default config (inline)"
           fi
 
-      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         id: link-check
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,0 +1,72 @@
+name: Check Markdown Links
+
+on:
+  workflow_call:
+    inputs:
+      config-file:
+        description: 'Path to markdown-link-check config file. If not found, falls back to default config from devtools.'
+        required: false
+        type: string
+        default: '.markdown-link-check.json'
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use default config if repo config not found
+        id: config
+        shell: bash
+        run: |
+          CONFIG_FILE="${{ inputs.config-file }}"
+          if [ -f "$CONFIG_FILE" ]; then
+            echo "config-path=$CONFIG_FILE" >> "$GITHUB_OUTPUT"
+            echo "Using repo config: $CONFIG_FILE"
+          else
+            echo "Repo config not found, downloading default from devtools..."
+            curl -sSfL \
+              "https://raw.githubusercontent.com/strands-agents/devtools/main/markdown-link-check/default-config.json" \
+              -o ".markdown-link-check-default.json"
+            echo "config-path=.markdown-link-check-default.json" >> "$GITHUB_OUTPUT"
+            echo "Using default devtools config"
+          fi
+
+      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+        id: link-check
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: ${{ steps.config.outputs.config-path }}
+        continue-on-error: true
+
+      - name: Create issue if links are broken
+        if: steps.link-check.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🔗 Broken markdown links detected';
+            const label = 'broken-links';
+
+            // Check for existing open issue to avoid duplicates
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              console.log(`Issue already exists: #${existing.data[0].number}`);
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: `The weekly markdown link check found broken links.\n\nSee the [workflow run](${runUrl}) for details.`,
+              labels: [label],
+            });

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       config-file:
-        description: 'Path to markdown-link-check config file. If not found, falls back to default config from devtools.'
+        description: 'Path to markdown-link-check config file. If not found, falls back to inline default config.'
         required: false
         type: string
         default: '.markdown-link-check.json'
@@ -24,12 +24,11 @@ jobs:
             echo "config-path=$CONFIG_FILE" >> "$GITHUB_OUTPUT"
             echo "Using repo config: $CONFIG_FILE"
           else
-            echo "Repo config not found, downloading default from devtools..."
-            curl -sSfL \
-              "https://raw.githubusercontent.com/strands-agents/devtools/main/markdown-link-check/default-config.json" \
-              -o ".markdown-link-check-default.json"
+            echo "Repo config not found, using inline default config..."
+            echo '{"retryOn429":true,"retryCount":3,"fallbackRetryDelay":"30s","aliveStatusCodes":[200,206]}' \
+              > ".markdown-link-check-default.json"
             echo "config-path=.markdown-link-check-default.json" >> "$GITHUB_OUTPUT"
-            echo "Using default devtools config"
+            echo "Using default config (inline)"
           fi
 
       - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17

--- a/markdown-link-check/README.md
+++ b/markdown-link-check/README.md
@@ -1,0 +1,42 @@
+# Markdown Link Check
+
+Reusable workflow for weekly markdown link checking across Strands Agents repositories.
+
+## Usage
+
+Add this to your repository at `.github/workflows/check-markdown-links.yml`:
+
+```yaml
+name: Check Markdown Links
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    uses: strands-agents/devtools/.github/workflows/check-markdown-links.yml@main
+```
+
+## Configuration
+
+The workflow uses a default config from this directory. To customize per-repo, add a `.markdown-link-check.json` file to your repository root:
+
+```json
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
+}
+```
+
+If no repo-level config is found, the [default config](./default-config.json) is used automatically.
+
+## How It Works
+
+1. Runs weekly (Monday 9am UTC) or on manual dispatch
+2. Scans all markdown files for broken links
+3. If broken links are found, creates a GitHub issue with the `broken-links` label
+4. Skips issue creation if one already exists (avoids duplicates)

--- a/markdown-link-check/default-config.json
+++ b/markdown-link-check/default-config.json
@@ -1,0 +1,6 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
+}


### PR DESCRIPTION
## Description

Centralizes the markdown link check workflow as a reusable workflow in devtools, so all Strands Agents repositories can call it instead of duplicating the workflow definition.

### What's included

| File | Purpose |
|---|---|
| `.github/workflows/check-markdown-links.yml` | Reusable workflow with `workflow_call` trigger |
| `markdown-link-check/default-config.json` | Default config used when repos don't have their own |
| `markdown-link-check/README.md` | Usage documentation |

### How repos use it

Each repo just needs a thin caller workflow:

```yaml
name: Check Markdown Links

on:
  schedule:
    - cron: '0 9 * * 1'
  workflow_dispatch:

jobs:
  check-links:
    uses: strands-agents/devtools/.github/workflows/check-markdown-links.yml@main
```

### Config override

Repos can optionally add their own `.markdown-link-check.json` for custom settings. If none exists, the default config from this repo is used.

## Related

- Request: https://github.com/strands-agents/sdk-typescript/pull/799#issuecomment-4209365609
- Original issue: strands-agents/sdk-python#1905
- Will update: strands-agents/sdk-typescript#799, strands-agents/tools#446, strands-agents/evals#188

## Type of Change

CI

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.