### PR TITLE
chore: do not run integ tests automatically on draft prs

### DIFF
--- a/authorization-check/action.yml
+++ b/authorization-check/action.yml
@@ -51,4 +51,4 @@ runs:
       with:
         result-encoding: string
         script: |
-          return ""
+          return "auto-approve"

--- a/authorization-check/action.yml
+++ b/authorization-check/action.yml
@@ -51,4 +51,4 @@ runs:
       with:
         result-encoding: string
         script: |
-          return "auto-approve"
+          return ""

--- a/authorization-check/scripts/check-authorization.cjs
+++ b/authorization-check/scripts/check-authorization.cjs
@@ -5,10 +5,15 @@
  * @param {object} options - Configuration options
  * @param {string} options.username - Username to check (required)
  * @param {string} options.allowedRoles - Comma-separated list of allowed roles (required)
- * @returns {Promise<string>} 'auto-approve' or 'manual-approval'
+ * @returns {Promise<string>} '' or 'manual-approval'
  */
 
 async function checkAuthorization(context, github, options) {
+  if (context.payload.pull_request?.draft) {
+    console.log(`PR is a draft. Requiring manual approval.`);
+    return "manual-approval";
+  }
+
   if (!options.username) {
     throw new Error('Username is required but was not provided');
   }
@@ -32,7 +37,7 @@ async function checkAuthorization(context, github, options) {
     return "manual-approval";
   } else {
     console.log(`Verified ${options.username} has write access (role: ${role_name}). Auto Approving.`);
-    return "auto-approve";
+    return "";
   }
 
 }

--- a/authorization-check/scripts/check-authorization.cjs
+++ b/authorization-check/scripts/check-authorization.cjs
@@ -5,7 +5,7 @@
  * @param {object} options - Configuration options
  * @param {string} options.username - Username to check (required)
  * @param {string} options.allowedRoles - Comma-separated list of allowed roles (required)
- * @returns {Promise<string>} '' or 'manual-approval'
+ * @returns {Promise<string>} 'auto-approve' or 'manual-approval'
  */
 
 async function checkAuthorization(context, github, options) {
@@ -37,7 +37,7 @@ async function checkAuthorization(context, github, options) {
     return "manual-approval";
   } else {
     console.log(`Verified ${options.username} has write access (role: ${role_name}). Auto Approving.`);
-    return "";
+    return "auto-approve";
   }
 
 }


### PR DESCRIPTION
*Description of changes:*

- Add draft PR gating to the authorization check — draft PRs now require manual approval regardless of author permissions

| Scenario | Output | Effect |
|----------|--------|--------|
| Draft PR (any author) | `manual-approval` | Needs approval |
| Published PR + maintainer | `auto-approve` | Runs automatically |
| Published PR + external | `manual-approval` | Needs approval |
| Merge queue (`skip-check: true`) | `auto-approve` | Runs automatically |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.