### PR TITLE
fix: only allow implementer mode to push commits to PRs

### DIFF
--- a/strands-command/actions/strands-finalize/action.yml
+++ b/strands-command/actions/strands-finalize/action.yml
@@ -27,14 +27,14 @@ runs:
           echo "🚫 Ref is default - skipping push operations to prevent direct commits to default branch"
         elif [ -n "${{ steps.read-input.outputs.head_repo }}" ]; then
           echo "🚫 Fork PR detected - skipping push operations (no write access to fork)"
-        elif [ "${{ steps.read-input.outputs.mode }}" = "reviewer" ]; then
-          echo "🚫 Reviewer mode - skipping push operations (review agent is read-only)"
+        elif [ "${{ steps.read-input.outputs.mode }}" != "implementer" ]; then
+          echo "🚫 Mode '${{ steps.read-input.outputs.mode }}' is not implementer - skipping push operations"
         else
           echo "✅ Ref is '${{ steps.read-input.outputs.ref }}' - push operations will proceed"
         fi
     
     - name: Download repository state artifact
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode != 'reviewer'
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode == 'implementer'
       uses: actions/download-artifact@v4
       with:
         name: repository-state
@@ -42,7 +42,7 @@ runs:
       continue-on-error: true
 
     - name: Apply Artifact and Push changes
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode != 'reviewer'
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode == 'implementer'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/strands-command/actions/strands-finalize/action.yml
+++ b/strands-command/actions/strands-finalize/action.yml
@@ -16,6 +16,7 @@ runs:
         echo "ref=$(jq -r .branch_name strands-parsed-input.json)" >> $GITHUB_OUTPUT
         echo "issue_id=$(jq -r .issue_id strands-parsed-input.json)" >> $GITHUB_OUTPUT
         echo "head_repo=$(jq -r '.head_repo // ""' strands-parsed-input.json)" >> $GITHUB_OUTPUT
+        echo "mode=$(jq -r '.mode // ""' strands-parsed-input.json)" >> $GITHUB_OUTPUT
 
     # Push code changes before running write commands in case we need to create a pull request
     # Pull requests cannot be created if a branch has no diff with main, so push changes first, then create pr
@@ -26,12 +27,14 @@ runs:
           echo "🚫 Ref is default - skipping push operations to prevent direct commits to default branch"
         elif [ -n "${{ steps.read-input.outputs.head_repo }}" ]; then
           echo "🚫 Fork PR detected - skipping push operations (no write access to fork)"
+        elif [ "${{ steps.read-input.outputs.mode }}" = "reviewer" ]; then
+          echo "🚫 Reviewer mode - skipping push operations (review agent is read-only)"
         else
           echo "✅ Ref is '${{ steps.read-input.outputs.ref }}' - push operations will proceed"
         fi
     
     - name: Download repository state artifact
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == ''
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode != 'reviewer'
       uses: actions/download-artifact@v4
       with:
         name: repository-state
@@ -39,7 +42,7 @@ runs:
       continue-on-error: true
 
     - name: Apply Artifact and Push changes
-      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == ''
+      if: steps.read-input.outputs.ref != github.event.repository.default_branch && steps.read-input.outputs.head_repo == '' && steps.read-input.outputs.mode != 'reviewer'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/strands-command/scripts/javascript/process-input.cjs
+++ b/strands-command/scripts/javascript/process-input.cjs
@@ -135,7 +135,8 @@ module.exports = async (context, github, core, inputs) => {
       system_prompt: systemPrompt,
       prompt: prompt,
       issue_id: issueId,
-      head_repo: headRepo
+      head_repo: headRepo,
+      mode: mode
     };
     
     fs.writeFileSync('strands-parsed-input.json', JSON.stringify(outputs, null, 2));


### PR DESCRIPTION
## Problem

The reviewer agent was pushing unintended commits to PRs (e.g. https://github.com/strands-agents/sdk-typescript/pull/1091). 

Root cause: the review agent's shell tool ran `git fetch origin main && git checkout FETCH_HEAD -- ...` to read repo guidelines, which overwrote working tree files with main's versions. The finalize step then detected dirty state, committed the diff as "Additional changes from write operations", and force-pushed it to the PR branch.

## Fix

- Add `mode` to the parsed input artifact (from `process-input.cjs`)
- In the finalize action, only allow the repository-state download and push when `mode == 'implementer'` (allowlist approach)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.