### PR TITLE
feat: Add issue-labeler composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This repo serves as a central location for:
 - **GitHub Actions & Workflows**: Reusable CI/CD workflows for building, testing, and releasing Strands Agents projects
 - **Shared Tooling**: Common scripts and utilities used across multiple repositories
 
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| [`issue-labeler`](issue-labeler/) | Classify issues using an LLM and apply labels from a configurable allowlist |
+| [`authorization-check`](authorization-check/) | Check user authorization for workflow triggers |
+| [`strands-command`](strands-command/) | Run a Strands agent in GitHub Actions |
+
 ## Documentation
 
 For more information about Strands Agents, visit our [documentation](https://strandsagents.com/latest/documentation/docs/).

--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -1,0 +1,131 @@
+# Issue Labeler
+
+A reusable GitHub Action that classifies issues using an LLM and applies labels from a hardcoded allowlist.
+
+## Security Model
+
+The LLM has no tools, no shell access, and no GitHub API access. Its output is parsed as JSON and validated against the label names defined in your config file. Invalid labels are silently dropped. The worst a prompt injection can achieve is mislabeling — never arbitrary label creation or other side effects.
+
+| Layer | Protection |
+|-------|-----------|
+| Input | Sanitized (control chars stripped) and truncated before reaching the LLM |
+| Output | Parsed as JSON, validated against frozen allowlist, capped at `max_labels` |
+| IAM | Scoped to `bedrock:InvokeModel` only |
+| Permissions | Workflow only needs `issues: write` |
+
+## Usage
+
+### Single labeler (file config)
+
+```yaml
+# .github/workflows/issue-labeler.yml
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  id-token: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/area.yml'
+```
+
+### Single labeler (inline config)
+
+```yaml
+- uses: strands-agents/devtools/issue-labeler@main
+  with:
+    aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+    max_labels: '1'
+    config: |
+      labels:
+        bug: "Something is broken"
+        enhancement: "New feature or improvement"
+        question: "User needs help"
+```
+
+### Multiple independent labelers
+
+Run separate jobs for each concern. They execute in parallel and don't conflict:
+
+```yaml
+jobs:
+  label-area:
+    steps:
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/area.yml'
+
+  label-type:
+    steps:
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/type.yml'
+          max_labels: '1'
+
+  label-language:
+    steps:
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/language.yml'
+          max_labels: '1'
+```
+
+## Config File Format
+
+```yaml
+# Optional: extra context appended to the system prompt
+instructions: |
+  CI dependency bumps should be labeled "chore".
+
+# Required: label allowlist. Keys are exact label names.
+# Values can be a string (description) or an object with a "description" key.
+labels:
+  area-mcp:
+    description: "Model Context Protocol, MCP servers/clients/transport"
+  area-provider:
+    description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama)"
+  # Shorthand form:
+  area-tool: "Tool behavior, execution, @tool decorator"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `aws_role_arn` | Yes | - | AWS IAM role for Bedrock |
+| `config` | No* | - | Inline YAML config |
+| `config_path` | No* | - | Path to config file |
+| `aws_region` | No | `us-west-2` | Bedrock region |
+| `model_id` | No | `anthropic.claude-haiku-4-5-20251001` | Model for classification |
+| `max_labels` | No | `3` | Max labels per issue |
+| `max_body_length` | No | `1000` | Max chars of body sent to LLM |
+
+*One of `config` or `config_path` is required.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `labels` | Comma-separated labels applied (empty string if none) |
+
+## Prerequisites
+
+1. An AWS IAM role that the GitHub OIDC provider can assume
+2. The role needs `bedrock:InvokeModel` permission
+3. The labels referenced in your config must already exist on the repo

--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -1,0 +1,99 @@
+name: 'Issue Labeler'
+description: 'Classify a GitHub issue using an LLM and apply labels from a hardcoded allowlist. Designed to be called multiple times with different configs for independent labeling concerns.'
+
+inputs:
+  aws_role_arn:
+    description: 'AWS IAM role ARN for Bedrock access'
+    required: true
+  config:
+    description: 'Inline YAML config defining labels and optional instructions. Use this OR config_path, not both.'
+    required: false
+    default: ''
+  config_path:
+    description: 'Path to a labeler config YAML file relative to repo root. Use this OR config, not both.'
+    required: false
+    default: ''
+  aws_region:
+    description: 'AWS region for Bedrock'
+    required: false
+    default: 'us-west-2'
+  model_id:
+    description: 'Bedrock model ID for classification'
+    required: false
+    default: 'anthropic.claude-haiku-4-5-20251001'
+  max_labels:
+    description: 'Maximum number of labels to apply per issue'
+    required: false
+    default: '3'
+  max_body_length:
+    description: 'Maximum characters of issue body to send to the LLM'
+    required: false
+    default: '1000'
+
+outputs:
+  labels:
+    description: 'Comma-separated list of labels that were applied (empty if none)'
+    value: ${{ steps.classify.outputs.labels }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws_role_arn }}
+        role-session-name: IssueLabeler-${{ github.run_id }}-${{ github.run_attempt }}
+        aws-region: ${{ inputs.aws_region }}
+        mask-aws-account-id: true
+        inline-session-policy: >-
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": ["bedrock:InvokeModel"],
+                "Resource": "*"
+              }
+            ]
+          }
+
+    - name: Install dependencies
+      shell: bash
+      run: pip install --quiet boto3 pyyaml
+
+    - name: Resolve config
+      id: config
+      shell: bash
+      env:
+        INLINE_CONFIG: ${{ inputs.config }}
+        CONFIG_PATH: ${{ inputs.config_path }}
+      run: |
+        if [ -n "$INLINE_CONFIG" ]; then
+          echo "$INLINE_CONFIG" > "${{ runner.temp }}/labeler-config.yml"
+        elif [ -n "$CONFIG_PATH" ]; then
+          if [ ! -f "$CONFIG_PATH" ]; then
+            echo "::error::Config file not found: $CONFIG_PATH"
+            exit 1
+          fi
+          cp "$CONFIG_PATH" "${{ runner.temp }}/labeler-config.yml"
+        else
+          echo "::error::Either 'config' or 'config_path' input is required."
+          exit 1
+        fi
+        echo "path=${{ runner.temp }}/labeler-config.yml" >> "$GITHUB_OUTPUT"
+
+    - name: Classify and apply labels
+      id: classify
+      shell: bash
+      env:
+        ISSUE_TITLE: ${{ github.event.issue.title }}
+        ISSUE_BODY: ${{ github.event.issue.body }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        CONFIG_PATH: ${{ steps.config.outputs.path }}
+        MODEL_ID: ${{ inputs.model_id }}
+        AWS_REGION: ${{ inputs.aws_region }}
+        MAX_LABELS: ${{ inputs.max_labels }}
+        MAX_BODY_LENGTH: ${{ inputs.max_body_length }}
+      run: python3 "${{ github.action_path }}/classify.py"

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Issue classifier for the issue-labeler GitHub Action.
+
+Reads a config file defining valid labels, calls Bedrock for classification,
+validates the response against the allowlist, and applies labels via gh CLI.
+
+Security model:
+- LLM output is validated against a hardcoded allowlist from the config file.
+- Issue content is sanitized and truncated before reaching the LLM.
+- The LLM has no tools, no shell access, no GitHub API access.
+- Worst case from prompt injection: mislabeling (not arbitrary actions).
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+import boto3
+import yaml
+
+
+def load_config(config_path: str) -> dict:
+    """Load and validate the labeler config file."""
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    if not config or "labels" not in config:
+        print("::error::Config must have a 'labels' key with label definitions.")
+        sys.exit(1)
+
+    if not isinstance(config["labels"], dict) or len(config["labels"]) == 0:
+        print("::error::Config 'labels' must be a non-empty mapping of label_name -> description.")
+        sys.exit(1)
+
+    return config
+
+
+def build_system_prompt(config: dict, max_labels: int) -> str:
+    """Build the classification prompt from config."""
+    label_lines = []
+    for label_name, label_def in config["labels"].items():
+        description = label_def if isinstance(label_def, str) else label_def.get("description", "")
+        label_lines.append(f"- {label_name}: {description}")
+
+    labels_block = "\n".join(label_lines)
+
+    prompt = f"""You are a GitHub issue classifier. Respond with ONLY a JSON array of label strings. No other text, no explanation, no markdown fences.
+
+Available labels:
+{labels_block}
+
+Rules:
+1. Assign 1-{max_labels} labels maximum.
+2. Only assign labels with clear evidence in the title or body.
+3. If unsure between multiple labels, prefer fewer labels over more.
+4. Respond with ONLY a JSON array. Example: ["label-one", "label-two"]"""
+
+    custom_instructions = config.get("instructions", "")
+    if custom_instructions:
+        prompt += f"\n\nAdditional context:\n{custom_instructions}"
+
+    return prompt
+
+
+def sanitize(text: str, max_len: int) -> str:
+    """Remove control characters and truncate."""
+    if not text:
+        return ""
+    cleaned = re.sub(r"[\x00-\x08\x0b-\x1f]", "", text)
+    return cleaned[:max_len]
+
+
+def classify_issue(title: str, body: str, system_prompt: str, valid_labels: frozenset) -> list[str]:
+    """Call Bedrock to classify the issue, return validated labels."""
+    model_id = os.environ.get("MODEL_ID", "anthropic.claude-haiku-4-5-20251001")
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    max_labels = int(os.environ.get("MAX_LABELS", "3"))
+
+    client = boto3.client("bedrock-runtime", region_name=region)
+
+    user_msg = f"Classify this issue:\n\nTitle: {title}\n\nBody:\n{body}"
+
+    request_body = json.dumps({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 150,
+        "temperature": 0,
+        "system": system_prompt,
+        "messages": [{"role": "user", "content": user_msg}],
+    })
+
+    response = client.invoke_model(
+        modelId=model_id,
+        contentType="application/json",
+        accept="application/json",
+        body=request_body,
+    )
+
+    response_body = json.loads(response["body"].read())
+    raw_text = response_body["content"][0]["text"].strip()
+    print(f"Raw LLM output: {raw_text}")
+
+    try:
+        labels = json.loads(raw_text)
+    except json.JSONDecodeError:
+        match = re.search(r"\[.*?\]", raw_text, re.DOTALL)
+        if match:
+            try:
+                labels = json.loads(match.group())
+            except json.JSONDecodeError:
+                return []
+        else:
+            return []
+
+    if not isinstance(labels, list):
+        return []
+
+    # SECURITY: Only accept labels from the hardcoded allowlist
+    validated = [l for l in labels if isinstance(l, str) and l in valid_labels]
+    return validated[:max_labels]
+
+
+def apply_labels(issue_number: str, labels: list[str]) -> None:
+    """Apply labels to the issue using gh CLI."""
+    repo = os.environ["GH_REPO"]
+    label_csv = ",".join(labels)
+
+    print(f"Applying labels to issue #{issue_number}: {label_csv}")
+    result = subprocess.run(
+        ["gh", "issue", "edit", issue_number, "--repo", repo, "--add-label", label_csv],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"::error::Failed to apply labels: {result.stderr}")
+        sys.exit(1)
+
+
+def main():
+    config_path = os.environ["CONFIG_PATH"]
+    max_body_length = int(os.environ.get("MAX_BODY_LENGTH", "1000"))
+    max_labels = int(os.environ.get("MAX_LABELS", "3"))
+
+    config = load_config(config_path)
+
+    valid_labels = frozenset(config["labels"].keys())
+    print(f"Loaded {len(valid_labels)} valid labels: {sorted(valid_labels)}")
+
+    system_prompt = build_system_prompt(config, max_labels)
+
+    title = sanitize(os.environ.get("ISSUE_TITLE", ""), 200)
+    body = sanitize(os.environ.get("ISSUE_BODY", ""), max_body_length)
+    issue_number = os.environ["ISSUE_NUMBER"]
+
+    if not title:
+        print("No issue title, skipping.")
+        sys.exit(0)
+
+    print(f"Classifying issue #{issue_number}: {title[:80]}")
+
+    labels = classify_issue(title, body, system_prompt, valid_labels)
+
+    if not labels:
+        print("No valid labels identified, skipping.")
+        sys.exit(0)
+
+    apply_labels(issue_number, labels)
+
+    # Write output for downstream steps
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        f.write(f"labels={','.join(labels)}\n")
+
+    print(f"Done: {labels}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Adds a reusable composite action for automated issue labeling. Repos define a YAML config with their label allowlist and optional classification instructions, then call this action from a thin workflow.

Supports running multiple independent labelers per repo (e.g. one for area tags, one for issue type, one for language) as separate parallel jobs with different configs.

### Security

The LLM has no tools, no shell access, and no GitHub API access. Its response is parsed as JSON and each label is validated against the config's hardcoded key set. Invalid labels are silently dropped. IAM is scoped to `bedrock:InvokeModel` only. The worst outcome from prompt injection is mislabeling.

### Structure

```
issue-labeler/
├── action.yml      # Composite action definition
├── classify.py     # Classification + allowlist validation
└── README.md       # Usage docs and config format
```

### Config format

Consuming repos add a YAML file like:

```yaml
instructions: |
  CI dependency bumps should be labeled "chore".

labels:
  area-mcp:
    description: "Model Context Protocol, MCP servers/clients/transport"
  area-provider:
    description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama)"
```

The action accepts either a `config_path` pointing to such a file, or inline YAML via the `config` input.

## Testing

- Validated config parsing and allowlist filtering logic locally
- Tested Bedrock invoke-model integration against live endpoint
- Verified that labels not in the config are rejected regardless of LLM output