### PR TITLE
fix: scope authorization-check permissions to contents: read

### DIFF
--- a/authorization-check/README.md
+++ b/authorization-check/README.md
@@ -16,7 +16,8 @@ A reusable GitHub Action that validates user permissions and determines the appr
 ```yaml
 jobs:
   authorization-check:
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}


### PR DESCRIPTION
## Summary

- Replace `permissions: read-all` with explicit `contents: read` in the authorization-check README usage example
- The action only requires repository read access (for `actions/checkout` and `repos.getCollaboratorPermissionLevel`) — `read-all` unnecessarily grants read access to actions, checks, deployments, id-token, issues, packages, pages, pull-requests, repository-projects, security-events, and statuses

## Test plan

- [ ] Verify a consuming workflow with `permissions: contents: read` on the authorization-check job still correctly resolves `auto-approve` / `manual-approval`