### PR TITLE
fix(strands-finalize): prevent base64 line-wrap corrupting git auth header

### DIFF
--- a/strands-command/actions/strands-finalize/action.yml
+++ b/strands-command/actions/strands-finalize/action.yml
@@ -87,7 +87,7 @@ runs:
           git config --local core.pager cat
           # We need to overwrite this since this is currently set by the previous readonly workflow artifact
           # Overwrite this value with the current token that allows us to push the commit
-          git config --local http."https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n x-access-token:${GITHUB_TOKEN}| base64)"
+          git config --local http."https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64 -w0)"
 
           # Fetch the remote repository
           git fetch origin "$REF"


### PR DESCRIPTION
## Summary

`strands-finalize` stage on the Strands agent fails to push and never opens a PR whenever the agent produces file changes. 

## Symptom

The `finalize` job dies at `git fetch origin <branch>`:

```
fatal: unable to access 'https://github.com/<owner>/<repo>/': Failed sending HTTP request
##[error]Process completed with exit code 128.
```

With `-e -o pipefail`, the job exits before `git push`, so no PR is created. Runs with no file changes skip the push path and look healthy, which hid the issue, but every run that actually reached the push path was failing.

## Root cause

The auth header was built with a bare `base64`, which wraps at 76 columns on the runner. Once `x-access-token:${GITHUB_TOKEN}` encodes past 76 chars, a newline is injected into `http.extraheader`, corrupting the credential. Latent since the action was created (`62d3b61`); started firing now that `GITHUB_TOKEN` grew past the wrap boundary.

## Fix

Force single-line output with `base64 -w0`:

```diff
- ... $(echo -n x-access-token:${GITHUB_TOKEN}| base64)"
+ ... $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64 -w0)"
```

## Testing

Trigger `/strands` on a task that produces file changes and confirm finalize logs `📤 Pushing changes` and opens a PR.