### PR TITLE
chore: update model to claude-opus-4-8

### DIFF
--- a/strands-command/scripts/python/agent_runner.py
+++ b/strands-command/scripts/python/agent_runner.py
@@ -45,7 +45,7 @@ from notebook import notebook
 from str_replace_based_edit_tool import str_replace_based_edit_tool
 
 # Strands configuration constants
-STRANDS_MODEL_ID = "global.anthropic.claude-opus-4-6-v1"
+STRANDS_MODEL_ID = "global.anthropic.claude-opus-4-8"
 STRANDS_MAX_TOKENS = 64000
 STRANDS_BUDGET_TOKENS = 8000
 STRANDS_REGION = "us-west-2"


### PR DESCRIPTION
## Summary

Updates `STRANDS_MODEL_ID` in `strands-command/scripts/python/agent_runner.py` to Opus 4.8.

```diff
- STRANDS_MODEL_ID = "global.anthropic.claude-opus-4-6-v1"
+ STRANDS_MODEL_ID = "global.anthropic.claude-opus-4-8"
```

## Note
Used the exact model ID requested: `global.anthropic.claude-opus-4-8`. The previous value carried a `-v1` suffix (`...opus-4-6-v1`) — if the new model also requires a version suffix (e.g. `-v1`), let me know and I'll adjust.

Requested by @mkmeral.

---
🤖 Generated by Strands Coder agent (issue agent-of-mkmeral/strands-coder-private#263)