### PR TITLE
feat(issue-labeler): support pull_request_target events

### DIFF
--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -86,9 +86,9 @@ runs:
       id: classify
       shell: bash
       env:
-        ISSUE_TITLE: ${{ github.event.issue.title }}
-        ISSUE_BODY: ${{ github.event.issue.body }}
-        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+        ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         CONFIG_PATH: ${{ steps.config.outputs.path }}


### PR DESCRIPTION
## Summary

- Use fallback expressions (`github.event.issue.* || github.event.pull_request.*`) for `ISSUE_TITLE`, `ISSUE_BODY`, and `ISSUE_NUMBER` env vars
- Allows the action to work for both `issues` and `pull_request_target` workflow triggers without changes

## Test plan

- [ ] Verify action still works for issue events (existing behavior)
- [ ] Verify action works for pull_request_target events (new behavior)