### PR TITLE
fix(issue-labeler): use valid Bedrock inference profile via Strands SDK

### DIFF
--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -1,16 +1,16 @@
 # Issue Labeler
 
-A reusable GitHub Action that classifies issues using an LLM and applies labels from a hardcoded allowlist.
+A reusable GitHub Action that classifies issues using an LLM (via the [Strands Agents SDK](https://github.com/strands-agents/sdk-python)) and applies labels from a hardcoded allowlist.
 
 ## Security Model
 
-The LLM has no tools, no shell access, and no GitHub API access. Its output is parsed as JSON and validated against the label names defined in your config file. Invalid labels are silently dropped. The worst a prompt injection can achieve is mislabeling — never arbitrary label creation or other side effects.
+The LLM has no tools, no shell access, and no GitHub API access. It returns a structured object whose label field is an enum built from the label names in your config file, so out-of-allowlist values are rejected by the schema rather than filtered after the fact. The worst a prompt injection can achieve is mislabeling — never arbitrary label creation or other side effects.
 
 | Layer | Protection |
 |-------|-----------|
 | Input | Sanitized (control chars stripped) and truncated before reaching the LLM |
-| Output | Parsed as JSON, validated against frozen allowlist, capped at `max_labels` |
-| IAM | Scoped to `bedrock:InvokeModel` only |
+| Output | Structured output constrained to an allowlist enum, capped at `max_labels` |
+| IAM | Scoped to `bedrock:InvokeModel` / `bedrock:InvokeModelWithResponseStream` |
 | Permissions | Workflow only needs `issues: write` |
 
 ## Usage
@@ -112,7 +112,7 @@ labels:
 | `config` | No* | - | Inline YAML config |
 | `config_path` | No* | - | Path to config file |
 | `aws_region` | No | `us-west-2` | Bedrock region |
-| `model_id` | No | `anthropic.claude-haiku-4-5-20251001` | Model for classification |
+| `model_id` | No | `global.anthropic.claude-sonnet-4-6` | Bedrock inference profile for classification |
 | `max_labels` | No | `3` | Max labels per issue |
 | `max_body_length` | No | `1000` | Max chars of body sent to LLM |
 
@@ -127,5 +127,6 @@ labels:
 ## Prerequisites
 
 1. An AWS IAM role that the GitHub OIDC provider can assume
-2. The role needs `bedrock:InvokeModel` permission
-3. The labels referenced in your config must already exist on the repo
+2. The role needs `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` permissions
+3. Bedrock access enabled for the configured model in `aws_region`
+4. The labels referenced in your config must already exist on the repo

--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -18,9 +18,9 @@ inputs:
     required: false
     default: 'us-west-2'
   model_id:
-    description: 'Bedrock model ID for classification'
+    description: 'Bedrock model ID (inference profile) for classification'
     required: false
-    default: 'anthropic.claude-haiku-4-5-20251001'
+    default: 'global.anthropic.claude-sonnet-4-6'
   max_labels:
     description: 'Maximum number of labels to apply per issue'
     required: false
@@ -51,7 +51,10 @@ runs:
             "Statement": [
               {
                 "Effect": "Allow",
-                "Action": ["bedrock:InvokeModel"],
+                "Action": [
+                  "bedrock:InvokeModel",
+                  "bedrock:InvokeModelWithResponseStream"
+                ],
                 "Resource": "*"
               }
             ]
@@ -59,7 +62,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet boto3 pyyaml
+      run: pip install --quiet strands-agents pyyaml
 
     - name: Resolve config
       id: config

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -2,24 +2,28 @@
 """
 Issue classifier for the issue-labeler GitHub Action.
 
-Reads a config file defining valid labels, calls Bedrock for classification,
-validates the response against the allowlist, and applies labels via gh CLI.
+Reads a config file defining valid labels, calls Bedrock (via the Strands
+SDK) for structured classification, and applies labels via gh CLI.
 
 Security model:
-- LLM output is validated against a hardcoded allowlist from the config file.
+- The LLM returns a structured object whose label field is an enum built
+  from the config allowlist, so out-of-allowlist values are rejected by the
+  schema rather than by hand.
 - Issue content is sanitized and truncated before reaching the LLM.
 - The LLM has no tools, no shell access, no GitHub API access.
 - Worst case from prompt injection: mislabeling (not arbitrary actions).
 """
 
-import json
+import enum
 import os
 import re
 import subprocess
 import sys
 
-import boto3
 import yaml
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models import BedrockModel
 
 
 def load_config(config_path: str) -> dict:
@@ -47,16 +51,16 @@ def build_system_prompt(config: dict, max_labels: int) -> str:
 
     labels_block = "\n".join(label_lines)
 
-    prompt = f"""You are a GitHub issue classifier. Respond with ONLY a JSON array of label strings. No other text, no explanation, no markdown fences.
+    prompt = f"""You are a GitHub issue classifier.
 
 Available labels:
 {labels_block}
 
 Rules:
-1. Assign 1-{max_labels} labels maximum.
+1. Assign at most {max_labels} labels.
 2. Only assign labels with clear evidence in the title or body.
 3. If unsure between multiple labels, prefer fewer labels over more.
-4. Respond with ONLY a JSON array. Example: ["label-one", "label-two"]"""
+4. If no label clearly applies, return an empty list."""
 
     custom_instructions = config.get("instructions", "")
     if custom_instructions:
@@ -73,53 +77,57 @@ def sanitize(text: str, max_len: int) -> str:
     return cleaned[:max_len]
 
 
+def build_classification_model(valid_labels: frozenset) -> type[BaseModel]:
+    """Build a Pydantic model whose label field is an enum of the allowlist.
+
+    SECURITY: the enum *is* the allowlist, so the structured-output schema
+    rejects any value the model invents that is not a configured label.
+    """
+    label_enum = enum.Enum("Label", {name: name for name in sorted(valid_labels)})
+
+    class Classification(BaseModel):
+        labels: list[label_enum] = Field(
+            default_factory=list,
+            description="Labels that apply to the issue, drawn only from the allowed set.",
+        )
+
+    return Classification
+
+
 def classify_issue(title: str, body: str, system_prompt: str, valid_labels: frozenset) -> list[str]:
-    """Call Bedrock to classify the issue, return validated labels."""
-    model_id = os.environ.get("MODEL_ID", "anthropic.claude-haiku-4-5-20251001")
+    """Call Bedrock via Strands to classify the issue, return validated labels."""
+    model_id = os.environ.get("MODEL_ID", "global.anthropic.claude-sonnet-4-6")
     region = os.environ.get("AWS_REGION", "us-west-2")
     max_labels = int(os.environ.get("MAX_LABELS", "3"))
 
-    client = boto3.client("bedrock-runtime", region_name=region)
+    model = BedrockModel(
+        model_id=model_id,
+        region_name=region,
+        temperature=0,
+        max_tokens=512,
+    )
+    agent = Agent(model=model, system_prompt=system_prompt)
 
+    classification_model = build_classification_model(valid_labels)
     user_msg = f"Classify this issue:\n\nTitle: {title}\n\nBody:\n{body}"
 
-    request_body = json.dumps({
-        "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 150,
-        "temperature": 0,
-        "system": system_prompt,
-        "messages": [{"role": "user", "content": user_msg}],
-    })
-
-    response = client.invoke_model(
-        modelId=model_id,
-        contentType="application/json",
-        accept="application/json",
-        body=request_body,
-    )
-
-    response_body = json.loads(response["body"].read())
-    raw_text = response_body["content"][0]["text"].strip()
-    print(f"Raw LLM output: {raw_text}")
-
     try:
-        labels = json.loads(raw_text)
-    except json.JSONDecodeError:
-        match = re.search(r"\[.*?\]", raw_text, re.DOTALL)
-        if match:
-            try:
-                labels = json.loads(match.group())
-            except json.JSONDecodeError:
-                return []
-        else:
-            return []
-
-    if not isinstance(labels, list):
+        result = agent.structured_output(classification_model, user_msg)
+    except Exception as e:  # noqa: BLE001 - classification failure must not fail the workflow
+        print(f"::warning::Classification failed: {e}")
         return []
 
-    # SECURITY: Only accept labels from the hardcoded allowlist
-    validated = [l for l in labels if isinstance(l, str) and l in valid_labels]
-    return validated[:max_labels]
+    # Enum members carry the label name as their value; dedupe preserving order.
+    seen: set[str] = set()
+    labels: list[str] = []
+    for member in result.labels:
+        name = member.value
+        if name not in seen:
+            seen.add(name)
+            labels.append(name)
+
+    print(f"Classified labels: {labels}")
+    return labels[:max_labels]
 
 
 def apply_labels(issue_number: str, labels: list[str]) -> None:

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -1,0 +1,40 @@
+"""Tests for the dynamic allowlist model in classify.py.
+
+These cover the security-critical piece: the classification schema must only
+accept labels from the configured allowlist. No Bedrock call is made.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from classify import build_classification_model, build_system_prompt, sanitize
+
+
+def test_accepts_allowlisted_labels():
+    model = build_classification_model(frozenset({"bug", "enhancement"}))
+    obj = model(labels=["bug", "enhancement"])
+    assert [m.value for m in obj.labels] == ["bug", "enhancement"]
+
+
+def test_rejects_out_of_allowlist_label():
+    model = build_classification_model(frozenset({"bug"}))
+    with pytest.raises(ValidationError):
+        model(labels=["bug", "not-a-real-label"])
+
+
+def test_defaults_to_empty_list():
+    model = build_classification_model(frozenset({"bug"}))
+    assert model().labels == []
+
+
+def test_system_prompt_lists_labels_and_cap():
+    config = {"labels": {"bug": "broken", "enhancement": {"description": "new"}}}
+    prompt = build_system_prompt(config, max_labels=2)
+    assert "- bug: broken" in prompt
+    assert "- enhancement: new" in prompt
+    assert "at most 2 labels" in prompt
+
+
+def test_sanitize_strips_control_chars_and_truncates():
+    assert sanitize("a\x00b\x1fc", 10) == "abc"
+    assert sanitize("abcdef", 3) == "abc"


### PR DESCRIPTION
## Summary

The issue-labeler action fails on every run because its default model id is invalid. This reimplements the classifier on the Strands Agents SDK, which fixes the model id and replaces the hand-rolled JSON parsing/allowlist filtering with schema-enforced structured output.

## Root cause

The default `model_id` is `anthropic.claude-haiku-4-5-20251001` — a bare model name. Bedrock requires an inference-profile id (e.g. `global.anthropic.claude-sonnet-4-6`), so `invoke_model` rejects the request and no labels are ever applied.

## Fix

- Replace `boto3.invoke_model` with `BedrockModel` + `Agent.structured_output` from the Strands SDK.
- Build the classification schema as a Pydantic model whose `labels` field is an enum derived from the config allowlist. Out-of-allowlist values are now rejected by the schema instead of being filtered after parsing, so the security guarantee (worst case = mislabeling) is preserved structurally and the manual JSON-array/regex extraction is gone.
- Default model is now the valid inference profile `global.anthropic.claude-sonnet-4-6`.
- Add `bedrock:InvokeModelWithResponseStream` to the IAM session policy (Strands streams via `converse_stream` by default).
- Bump `max_tokens` 150 → 512 for structured-output overhead.
- Install `strands-agents` instead of `boto3`.
- Add unit tests covering the allowlist constraint, empty default, prompt building, and sanitization.

## Testing

- [x] Unit tests pass (`pytest issue-labeler/test_classify.py`) — allowlist accepts in-list labels, rejects invented ones, defaults to empty, prompt lists labels and cap.
- [x] Live Bedrock classification with `global.anthropic.claude-sonnet-4-6`: a crash report classified as `bug`; a help question classified as `question`, `documentation` — both within the allowlist.
- [ ] Trigger the action on a real issue in CI to confirm end-to-end behavior with OIDC credentials.