### PR TITLE
fix(issue-labeler): pin boto3>=1.35 for Bedrock converse_stream

### DIFF
--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet strands-agents pyyaml
+      run: pip install --quiet --upgrade strands-agents pyyaml "boto3>=1.35.0"
 
     - name: Resolve config
       id: config


### PR DESCRIPTION
## Summary

Follow-up to #62. The Strands reimplementation runs, but classification fails at runtime on the GitHub runner with:

```
Warning: Classification failed: 'BedrockRuntime' object has no attribute 'converse_stream'
```

## Root cause

`BedrockModel` streams via the Bedrock Converse streaming API (`converse_stream`) by default. That API requires a recent boto3. `strands-agents` only floors `boto3>=1.26.0`, and the runner ships an older boto3 that satisfies that floor, so pip never upgrades it — leaving a client without `converse_stream`.

## Fix

Force a new-enough boto3 in the install step:

```diff
- run: pip install --quiet strands-agents pyyaml
+ run: pip install --quiet --upgrade strands-agents pyyaml "boto3>=1.35.0"
```

## Testing

- [ ] Re-run an affected consumer workflow (e.g. harness-sdk issue-labeler) and confirm labels are applied without the `converse_stream` error.