### PR TITLE
fix(runner): fixed agent-runner

### DIFF
--- a/strands-command/scripts/python/agent_runner.py
+++ b/strands-command/scripts/python/agent_runner.py
@@ -47,7 +47,6 @@ from str_replace_based_edit_tool import str_replace_based_edit_tool
 # Strands configuration constants
 STRANDS_MODEL_ID = "global.anthropic.claude-opus-4-8"
 STRANDS_MAX_TOKENS = 64000
-STRANDS_BUDGET_TOKENS = 8000
 STRANDS_REGION = "us-west-2"
 
 # Default values for environment variables used only in this file
@@ -193,12 +192,8 @@ def run_agent(query: str):
         
         # Create Bedrock model with inlined configuration
         additional_request_fields = {}
-        additional_request_fields["anthropic_beta"] = ["interleaved-thinking-2025-05-14"]
-        
-        additional_request_fields["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": STRANDS_BUDGET_TOKENS
-        }
+        additional_request_fields["thinking"] = {"type": "adaptive"}
+        additional_request_fields["output_config"] = {"effort": "high"}
         
         model = BedrockModel(
             model_id=STRANDS_MODEL_ID,


### PR DESCRIPTION
*Description of changes:*

Fix `ValidationException` from Bedrock when the agent runner calls Opus 4.8.

The runner was sending the legacy extended-thinking shape:

```python
additional_request_fields["anthropic_beta"] = ["interleaved-thinking-2025-05-14"]
additional_request_fields["thinking"] = {
    "type": "enabled",
    "budget_tokens": STRANDS_BUDGET_TOKENS,
}
```

Opus 4.8 (`global.anthropic.claude-opus-4-8`) rejects `thinking.type = "enabled"` and `budget_tokens` outright. ConverseStream returned:

> The model returned the following errors: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.

Example failing run: https://github.com/strands-agents/harness-sdk/actions/runs/27270540215/job/80538637489

**Changes:**
- Switch to adaptive thinking: `thinking = {"type": "adaptive"}`
- Add `output_config = {"effort": "high"}` to control thinking depth / token spend
- Drop the `interleaved-thinking-2025-05-14` beta header (adaptive thinking enables interleaved automatically and the header is incompatible with the new shape)
- Remove the now-unused `STRANDS_BUDGET_TOKENS` constant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.