### PR TITLE
feat(changelog): add changelog-release-pr composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repo serves as a central location for:
 | [`issue-labeler`](issue-labeler/) | Classify issues using an LLM and apply labels from a configurable allowlist |
 | [`authorization-check`](authorization-check/) | Check user authorization for workflow triggers |
 | [`strands-command`](strands-command/) | Run a Strands agent in GitHub Actions |
+| [`changelog-release-pr`](changelog-release-pr/) | Parse a GitHub release into the harness-sdk changelog and open a PR |
 
 ## Documentation
 

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -1,0 +1,48 @@
+# Changelog Release PR
+
+Composite action that turns a GitHub Release into a structured changelog entry
+for the docs site in `strands-agents/harness-sdk` and opens a PR there.
+
+Pipeline (deterministic — no LLM):
+
+1. Fetch the release (single tag) or all releases (backfill) from `source-repo`.
+2. Parse the auto-generated "What's Changed" body into structured entries
+   (conventional-commit type/scope, title, PR, author). "New Contributors"
+   lines are extracted separately and never become entries.
+3. Enrich each entry from its PR: `area-*` labels → areas, `breaking change`
+   label, merge-commit SHA, author. For monorepo releases the PR's changed
+   files gate entries by language (`strands-py` → python stream, `strands-ts` →
+   typescript, both → both, neither → omitted; new contributors with neither
+   are kept in both — people aren't noise). Enrichment degrades gracefully when
+   a PR can't be fetched.
+4. Render `site/src/content/changelog/<sdk>/<file>.md` matching the harness-sdk
+   content-collection schema. Human-written `highlights:` blocks and markdown
+   bodies survive re-syncs.
+5. Open a PR against `target-repo` via peter-evans/create-pull-request.
+
+## Inputs
+
+| Input | Required | Default | Notes |
+|---|---|---|---|
+| `source-repo` | yes | — | owner/repo the release belongs to |
+| `tag` | single mode | `''` | release tag to sync |
+| `mode` | no | `single` | `single` \| `backfill` |
+| `skip-existing` | no | `false` | backfill only: generate just the missing files (zero PR-API cost for existing ones, never regresses enrichment). Used by the daily cron backstop. |
+| `github-token` | yes | — | reads releases/PRs and opens the PR. Needs `contents:write` + `pull-requests:write` on `target-repo`. NOTE: PRs created with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows (required checks won't run) — use an App/PAT token where that matters. |
+| `target-repo` | no | `strands-agents/harness-sdk` | repo that hosts the changelog |
+
+## Consumers
+
+- `strands-agents/harness-sdk` `.github/workflows/changelog-sync.yml` — on
+  release + daily cron backstop (the cron also backstops evals).
+- `strands-agents/evals` `.github/workflows/changelog-sync.yml` — cross-repo
+  PR into harness-sdk on each evals release.
+
+## Tests
+
+```bash
+cd changelog-release-pr/scripts && node --test
+```
+
+Dependency-free `.cjs` modules run via `actions/github-script`; logic modules
+are pure with injected fetchers/fs, so the suite runs without network.

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -32,7 +32,8 @@ Pipeline (deterministic — no LLM):
 | `tag` | single mode | `''` | release tag to sync |
 | `mode` | no | `single` | `single` \| `backfill` |
 | `skip-existing` | no | `false` | backfill only: generate just the missing files (zero PR-API cost for existing ones, never regresses enrichment). Used by the daily cron backstop. |
-| `github-token` | yes | — | reads releases/PRs and opens the PR. Needs `contents:write` + `pull-requests:write` on `target-repo`. NOTE: PRs created with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows (required checks won't run) — use an App/PAT token where that matters. |
+| `github-token` | yes | — | reads releases/PRs and opens the PR. Same-repo push: needs `contents:write` + `pull-requests:write` on `target-repo`. Fork flow (see `push-to-fork`): a classic PAT with the `public_repo` scope is sufficient — it grants write to the account's own fork plus cross-repo PR creation against the public upstream. NOTE: PRs created with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows (required checks won't run); a real-user PAT (or fork PR) does — use one where that matters. |
+| `push-to-fork` | no | `''` | `owner/repo` of a fork to push the PR branch to, for tokens whose account can't push to `target-repo` directly (an outside collaborator). The branch lands on the fork; the PR is still opened against `target-repo`. Empty = same-repo branch push. |
 | `target-repo` | no | `strands-agents/harness-sdk` | repo that hosts the changelog |
 
 ## Consumers

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -42,6 +42,19 @@ Pipeline (deterministic — no LLM):
 - `strands-agents/evals` `.github/workflows/changelog-sync.yml` — cross-repo
   PR into harness-sdk on each evals release.
 
+## Re-syncing existing files
+
+The daily cron runs with `skip-existing: true`, so it only writes files that
+don't exist yet and never touches committed ones. A full refresh
+(`skip-existing: false`, or a `backfill` dispatch) re-renders **every** release
+through the current renderer. The renderer emits the canonical, fully-expanded
+entry shape (every field present: `breaking`, `commit`, `commitUrl`, …), so the
+first full refresh after any hand-edited or terser committed files will produce
+a large reformat-only diff — frontmatter is rewritten to canonical form even
+where nothing changed semantically. Human-authored `highlights:` and markdown
+bodies are preserved (see below); only the generated frontmatter reformats.
+Expect and skim that churn; it's cosmetic.
+
 ## Tests
 
 ```bash

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -6,9 +6,13 @@ for the docs site in `strands-agents/harness-sdk` and opens a PR there.
 Pipeline (deterministic — no LLM):
 
 1. Fetch the release (single tag) or all releases (backfill) from `source-repo`.
-2. Parse the auto-generated "What's Changed" body into structured entries
-   (conventional-commit type/scope, title, PR, author). "New Contributors"
-   lines are extracted separately and never become entries.
+2. Derive structured entries from the GitHub **compare API**: list every merged
+   commit between the prior tag in the same stream and this release, resolve
+   each to its PR (commit→PR API), and classify the PR title
+   (conventional-commit type/scope). This is independent of how the release
+   notes are written, so it doesn't break when the body format drifts. The
+   release body is NOT parsed for entries; "New Contributors" lines are still
+   extracted from it separately and never become entries.
 3. Enrich each entry from its PR: `area-*` labels → areas, `breaking change`
    label, merge-commit SHA, author. For monorepo releases the PR's changed
    files gate entries by language (`strands-py` → python stream, `strands-ts` →

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -102,7 +102,7 @@ Two curated fields, both survive re-syncs (the parser never overwrites them):
 Copy this skeleton into a release file's body (after the frontmatter). The
 frontmatter itself is generated; you add `highlights:` and the body.
 
-```markdown
+````markdown
 ---
 # ...generated frontmatter (sdk, language, version, tag, date, urls, entries,
 # newContributors)...
@@ -124,9 +124,10 @@ Short narrative. Note any migration steps or breaking behavior here.
 ### Notes
 
 - Smaller call-outs, deprecations, or upgrade guidance as a short list.
-```
+````
 
-The six files under `site/src/content/changelog/` that carry hand-written
-bodies today (`harness/python-v1.25.0`, `harness/python-v1.35.0`,
-`harness/typescript-v0.2.1`, `harness/typescript-v1.0.0-rc.3`, `evals/v0.1.5`,
-`evals/v0.1.14`) follow this convention and serve as worked examples.
+The files under `site/src/content/changelog/` that carry hand-written bodies
+today (`harness/python-v1.25.0`, `harness/python-v1.35.0`,
+`harness/typescript-v0.2.1`, `harness/typescript-v1.0.0-rc.3`, `evals/v0.1.0`,
+`evals/v0.1.5`, `evals/v0.1.14`) follow this convention and serve as worked
+examples.

--- a/changelog-release-pr/README.md
+++ b/changelog-release-pr/README.md
@@ -46,3 +46,69 @@ cd changelog-release-pr/scripts && node --test
 
 Dependency-free `.cjs` modules run via `actions/github-script`; logic modules
 are pure with injected fetchers/fs, so the suite runs without network.
+
+## Authoring curated (narrative) release notes
+
+The generated file gives every release a structured summary (entries grouped
+into Features / Fixes / Other, area tags, first-time-contributor chips). For
+high-visibility releases you can add a hand-written narrative on top — prose,
+code samples, migration notes — that renders on the release's detail page and,
+namespaced, on the combined changelog. These are the best customer-facing
+changelogs; write them when there's manpower to.
+
+Two curated fields, both survive re-syncs (the parser never overwrites them):
+
+- **`highlights:`** — a short YAML string (1–3 sentences, inline markdown OK)
+  shown in an accent callout at the top of the release. Use for a quick "why
+  this release matters."
+- **markdown body** — everything after the closing `---`. Long-form narrative.
+
+### Conventions (so curated notes stay consistent and valid)
+
+1. **Don't restate the structured data.** The frontmatter already renders the
+   per-PR entry list and the first-time-contributor chips. A curated body must
+   NOT include GitHub's auto-generated `## What's Changed` /
+   `## New Contributors` / `**Full Changelog**` scaffolding — that duplicates
+   the chips/entries and (because every release reuses those headings) produced
+   colliding heading ids on the combined page. Keep only the human narrative.
+2. **Start body headings at `###`.** The version number is the page heading
+   (`h1` on the detail page); section headings inside the body should be `###`
+   or deeper so the outline stays well-formed.
+3. **Lead with the "why."** Describe what changed and why a user cares, then
+   show a minimal code sample. Link PRs inline as `[PR#1234](url)`.
+4. **Set `areas`/types via PR labels**, not prose — the structured summary is
+   generated from `area-*` labels and conventional-commit titles.
+
+### Template
+
+Copy this skeleton into a release file's body (after the frontmatter). The
+frontmatter itself is generated; you add `highlights:` and the body.
+
+```markdown
+---
+# ...generated frontmatter (sdk, language, version, tag, date, urls, entries,
+# newContributors)...
+highlights: Adds X and Y; migrates Z. One or two sentences on why it matters.
+---
+
+### Headline feature — [PR#1234](https://github.com/strands-agents/harness-sdk/pull/1234)
+
+One or two paragraphs on what it does and why, in plain language.
+
+```python
+# a minimal, runnable example of the new capability
+```
+
+### Another notable change — [PR#1240](https://github.com/strands-agents/harness-sdk/pull/1240)
+
+Short narrative. Note any migration steps or breaking behavior here.
+
+### Notes
+
+- Smaller call-outs, deprecations, or upgrade guidance as a short list.
+```
+
+The six files under `site/src/content/changelog/` that carry hand-written
+bodies today (`harness/python-v1.25.0`, `harness/python-v1.35.0`,
+`harness/typescript-v0.2.1`, `harness/typescript-v1.0.0-rc.3`, `evals/v0.1.5`,
+`evals/v0.1.14`) follow this convention and serve as worked examples.

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -38,7 +38,10 @@ runs:
       uses: actions/checkout@v6
       with:
         repository: strands-agents/devtools
-        ref: main
+        # Track the ref the CALLER pinned this action to, so pinning
+        # `uses: ...@<sha>` pins the scripts too (a hard-coded `main` here
+        # would let script behavior float regardless of the caller's pin).
+        ref: ${{ github.action_ref }}
         sparse-checkout: |
           changelog-release-pr/scripts
         path: devtools
@@ -60,7 +63,9 @@ runs:
           await runAction(github, context, core)
 
     - name: Open PR
-      uses: peter-evans/create-pull-request@v7
+      # Third-party action receiving a write-scoped token — pinned to a full
+      # commit SHA (v7.0.x) rather than a movable tag.
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         token: ${{ inputs.github-token }}
         path: target

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -1,0 +1,72 @@
+name: 'Changelog Release PR'
+description: 'Parse a GitHub release into the harness-sdk changelog collection and open a PR'
+inputs:
+  source-repo:
+    description: 'owner/repo the release belongs to (e.g. strands-agents/evals)'
+    required: true
+  tag:
+    description: 'Release tag to sync (single mode). Omit for backfill.'
+    required: false
+    default: ''
+  mode:
+    description: 'single | backfill'
+    required: false
+    default: 'single'
+  github-token:
+    description: 'Token to read releases/PRs and open the PR. Needs pull-requests:write (and contents:write) on target-repo.'
+    required: true
+  target-repo:
+    description: 'Repo to open the changelog PR against'
+    required: false
+    default: 'strands-agents/harness-sdk'
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout target repo
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.target-repo }}
+        token: ${{ inputs.github-token }}
+        path: target
+        fetch-depth: 0
+
+    - name: Checkout devtools (scripts)
+      uses: actions/checkout@v6
+      with:
+        repository: strands-agents/devtools
+        ref: main
+        sparse-checkout: |
+          changelog-release-pr/scripts
+        path: devtools
+        persist-credentials: false
+
+    - name: Generate changelog files
+      id: generate
+      uses: actions/github-script@v8
+      env:
+        SOURCE_REPO: ${{ inputs.source-repo }}
+        TAG: ${{ inputs.tag }}
+        MODE: ${{ inputs.mode }}
+        TARGET_DIR: ${{ github.workspace }}/target
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const runAction = require('./devtools/changelog-release-pr/scripts/run-action.cjs')
+          await runAction(github, context, core)
+
+    - name: Open PR
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ inputs.github-token }}
+        path: target
+        branch: changelog/sync-${{ inputs.source-repo == 'strands-agents/evals' && 'evals' || 'harness' }}-${{ inputs.tag || 'backfill' }}
+        title: "docs(changelog): sync ${{ inputs.source-repo }} ${{ inputs.tag || 'backfill' }}"
+        body: |
+          Automated changelog sync for `${{ inputs.source-repo }}` ${{ inputs.tag || '(backfill)' }}.
+
+          Add a curated `highlights:` block to any release file before merging if desired.
+
+          ${{ steps.generate.outputs.warnings != '' && '⚠️ Parser warnings were logged in the workflow run — review before merge.' || '' }}
+        commit-message: "docs(changelog): sync ${{ inputs.source-repo }} ${{ inputs.tag || 'backfill' }}"
+        delete-branch: true
+        draft: false

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -37,10 +37,12 @@ runs:
     - name: Checkout devtools (scripts)
       uses: actions/checkout@v6
       with:
-        repository: strands-agents/devtools
-        # Track the ref the CALLER pinned this action to, so pinning
-        # `uses: ...@<sha>` pins the scripts too (a hard-coded `main` here
-        # would let script behavior float regardless of the caller's pin).
+        # Track BOTH the repo and ref the caller pinned this action to, so
+        # `uses: <owner>/devtools/changelog-release-pr@<sha>` pins the scripts to
+        # that same owner+sha — including forks/mirrors. Hard-coding the repo (or
+        # ref) here would let script behavior float regardless of the caller's
+        # pin, and would break a fork whose ref doesn't exist upstream.
+        repository: ${{ github.action_repository }}
         ref: ${{ github.action_ref }}
         sparse-checkout: |
           changelog-release-pr/scripts

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -17,8 +17,21 @@ inputs:
     required: false
     default: 'false'
   github-token:
-    description: 'Token to read releases/PRs and open the PR. Needs pull-requests:write (and contents:write) on target-repo.'
+    description: >
+      Token to read releases/PRs and open the PR. For a same-repo PR the token
+      needs contents:write + pull-requests:write on target-repo. For the
+      fork-based flow (push-to-fork set, e.g. an account outside the org), it
+      instead needs write on the FORK and only public/read on target-repo — a
+      classic PAT with the `public_repo` scope is sufficient.
     required: true
+  push-to-fork:
+    description: >
+      owner/repo of a fork to push the PR branch to (e.g. strands-agent/harness-sdk).
+      Use when the token's account cannot push to target-repo directly (outside
+      collaborator). Leave empty for a same-repo branch push. The branch lands on
+      the fork; the PR is still opened against target-repo.
+    required: false
+    default: ''
   target-repo:
     description: 'Repo to open the changelog PR against'
     required: false
@@ -68,8 +81,16 @@ runs:
       # Third-party action receiving a write-scoped token — pinned to a full
       # commit SHA (v7.0.x) rather than a movable tag.
       uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+      # Do NOT add labels/assignees/reviewers/team-reviewers/milestone here: in
+      # the push-to-fork flow the token only has read/public on target-repo, and
+      # create-pull-request silently drops those fields without write on the
+      # parent — they'd appear to work locally and no-op in production.
       with:
         token: ${{ inputs.github-token }}
+        # When set, push the branch to this fork and open a cross-repo PR against
+        # target-repo (for tokens whose account can't push to target-repo
+        # directly). Empty = same-repo branch push.
+        push-to-fork: ${{ inputs.push-to-fork }}
         path: target
         branch: ${{ steps.generate.outputs.branch }}
         title: "docs(changelog): sync ${{ inputs.source-repo }} ${{ inputs.tag || 'backfill' }}"

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'single | backfill'
     required: false
     default: 'single'
+  skip-existing:
+    description: 'In backfill mode, only generate files for releases without one (cheap daily backstop; avoids re-enrichment API cost and never regresses existing files). Set false for a full refresh.'
+    required: false
+    default: 'false'
   github-token:
     description: 'Token to read releases/PRs and open the PR. Needs pull-requests:write (and contents:write) on target-repo.'
     required: true
@@ -47,6 +51,7 @@ runs:
         SOURCE_REPO: ${{ inputs.source-repo }}
         TAG: ${{ inputs.tag }}
         MODE: ${{ inputs.mode }}
+        SKIP_EXISTING: ${{ inputs.skip-existing }}
         TARGET_DIR: ${{ github.workspace }}/target
       with:
         github-token: ${{ inputs.github-token }}

--- a/changelog-release-pr/action.yml
+++ b/changelog-release-pr/action.yml
@@ -59,7 +59,7 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         path: target
-        branch: changelog/sync-${{ inputs.source-repo == 'strands-agents/evals' && 'evals' || 'harness' }}-${{ inputs.tag || 'backfill' }}
+        branch: ${{ steps.generate.outputs.branch }}
         title: "docs(changelog): sync ${{ inputs.source-repo }} ${{ inputs.tag || 'backfill' }}"
         body: |
           Automated changelog sync for `${{ inputs.source-repo }}` ${{ inputs.tag || '(backfill)' }}.

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -75,6 +75,23 @@ async function buildReleaseFile(repo, release, deps) {
     })
   }
 
+  // New contributors: language-gate like entries, with one deliberate
+  // difference — a first PR that touches NO sdk dir (docs/ci/site) is still
+  // celebrated in BOTH streams (entries with no language are dropped as noise;
+  // people aren't noise). Unknown file info → also kept in both.
+  let newContributors = parseNewContributors(release.body)
+  if (isMonorepoStream) {
+    const gated = []
+    for (const c of newContributors) {
+      const enr = await deps.enrich(repo, c.pr)
+      const langs = enr.languages
+      if (!Array.isArray(langs) || langs.length === 0 || langs.includes(meta.language)) {
+        gated.push(c)
+      }
+    }
+    newContributors = gated
+  }
+
   const file = {
     sdk: meta.sdk,
     language: meta.language,
@@ -84,7 +101,7 @@ async function buildReleaseFile(repo, release, deps) {
     releaseUrl: release.html_url,
     packageUrl: getPackageUrl(meta.sdk, meta.language, meta.version),
     entries,
-    newContributors: parseNewContributors(release.body),
+    newContributors,
   }
 
   const contents = existing ? mergePreserving(file, existing) : renderMarkdown(file)

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -2,7 +2,7 @@
 // injected deps (enrich + readExisting), so it's unit-testable without network.
 
 const { tagToMeta, getPackageUrl } = require('./tag-meta.cjs')
-const { parseReleaseBody, countChangelogBullets } = require('./parse-release-body.cjs')
+const { parseReleaseBody, countChangelogBullets, parseNewContributors } = require('./parse-release-body.cjs')
 const { renderMarkdown, mergePreserving } = require('./render-markdown.cjs')
 
 function fileNameFor(sdk, language, version) {
@@ -84,6 +84,7 @@ async function buildReleaseFile(repo, release, deps) {
     releaseUrl: release.html_url,
     packageUrl: getPackageUrl(meta.sdk, meta.language, meta.version),
     entries,
+    newContributors: parseNewContributors(release.body),
   }
 
   const contents = existing ? mergePreserving(file, existing) : renderMarkdown(file)

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -41,12 +41,25 @@ async function buildReleaseFile(repo, release, deps) {
       ? `${release.tag_name}: parsed ${parsed.length} of ${bullets} changelog bullets — release-note format may have changed; review before merge.`
       : undefined
 
+  // Monorepo releases (prefixed tags) list every merged PR regardless of
+  // language, so gate entries by which SDK dirs the PR actually touched:
+  // python stream keeps python-touching PRs, ts stream keeps ts-touching,
+  // both → both, site/ci/docs-only (empty languages) → omitted everywhere,
+  // unknown (file info unavailable) → kept (degrade open). Pre-monorepo
+  // bare-`v` tags and evals are single-language releases — no filtering.
+  const isMonorepoStream =
+    meta.sdk === 'harness' &&
+    (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
+
   const entries = []
   for (const p of parsed) {
     const prRepo = p.prRepo || repo
     const enr = p.pr
       ? await deps.enrich(prRepo, p.pr)
-      : { areas: [], breaking: false, commit: null, author: null }
+      : { areas: [], breaking: false, commit: null, author: null, languages: null }
+    if (isMonorepoStream && Array.isArray(enr.languages) && !enr.languages.includes(meta.language)) {
+      continue
+    }
     const breaking = p.breaking || enr.breaking
     entries.push({
       type: breaking && p.type === 'other' ? 'breaking' : p.type,

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -13,7 +13,7 @@ function fileNameFor(sdk, language, version) {
 /**
  * @param {string} repo  the SOURCE repo the release belongs to
  * @param {{tag_name:string, published_at:string, html_url:string, body:string|null}} release
- * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null}>, readExisting:(path:string)=>Promise<string|null>, skipExisting?:boolean}} deps
+ * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null,languages:string[]|null,docsOnly:boolean}>, readExisting:(path:string)=>Promise<string|null>, skipExisting?:boolean}} deps
  * @returns {Promise<{path:string, contents:string, warning?:string}|null>}
  */
 async function buildReleaseFile(repo, release, deps) {

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -59,16 +59,21 @@ async function buildReleaseFile(repo, release, deps) {
     meta.sdk === 'harness' &&
     (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
 
+  // Shared keep/drop decision for both entries and new contributors: drop a
+  // docs-only PR from every stream, and on a monorepo stream drop a PR with a
+  // POSITIVE dir signal for the OTHER language (empty/unknown languages are
+  // kept — see the language-gate note above).
+  const dropFromStream = (enr) =>
+    enr.docsOnly ||
+    (isMonorepoStream && Array.isArray(enr.languages) && enr.languages.length > 0 && !enr.languages.includes(meta.language))
+
   const entries = []
   for (const p of parsed) {
     const prRepo = p.prRepo || repo
     const enr = p.pr
       ? await deps.enrich(prRepo, p.pr)
       : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
-    if (enr.docsOnly) continue
-    if (isMonorepoStream && Array.isArray(enr.languages) && enr.languages.length > 0 && !enr.languages.includes(meta.language)) {
-      continue
-    }
+    if (dropFromStream(enr)) continue
     const breaking = p.breaking || enr.breaking
     entries.push({
       type: breaking && p.type === 'other' ? 'breaking' : p.type,
@@ -84,28 +89,18 @@ async function buildReleaseFile(repo, release, deps) {
     })
   }
 
-  // New contributors gate. A docs-only first PR (blog/site/docs) is dropped on
-  // every stream — same focus rule as entries; a blog-only contributor doesn't
-  // belong in an SDK+language changelog. Beyond that, on monorepo streams we
-  // language-gate, with one deliberate softness: a first PR that touches NO sdk
-  // dir but isn't docs-only (e.g. ci) is still celebrated in BOTH streams, and
-  // unknown file info is kept (people aren't noise). Pre-monorepo/evals streams
-  // keep everyone who isn't docs-only.
+  // New contributors use the same keep/drop rule as entries (dropFromStream):
+  // a docs-only first PR doesn't belong in an SDK+language changelog, and a
+  // monorepo PR with a positive other-language signal is gated out — but a
+  // first PR touching no sdk dir (e.g. ci) or with unknown files is kept in
+  // both streams: people aren't noise.
   const rawContributors = parseNewContributors(release.body)
   const newContributors = []
   for (const c of rawContributors) {
     // Use the PR's own repo (mirrors the entries path) — first-contribution
     // links can point at the pre-monorepo repos.
-    const prRepo = c.prRepo || repo
-    const enr = await deps.enrich(prRepo, c.pr)
-    if (enr.docsOnly) continue
-    // Mirror the entries gate: only drop when the PR has a positive dir signal
-    // for the OTHER language. Empty/unknown languages (no dir signal, or a
-    // first PR touching only root/ci) are kept — people aren't noise.
-    const langs = enr.languages
-    if (isMonorepoStream && Array.isArray(langs) && langs.length > 0 && !langs.includes(meta.language)) {
-      continue
-    }
+    const enr = await deps.enrich(c.prRepo || repo, c.pr)
+    if (dropFromStream(enr)) continue
     newContributors.push(c)
   }
 

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -1,0 +1,72 @@
+// Orchestrate one GitHub release into a rendered changelog file. Pure given
+// injected deps (enrich + readExisting), so it's unit-testable without network.
+
+const { tagToMeta, getPackageUrl } = require('./tag-meta.cjs')
+const { parseReleaseBody, countChangelogBullets } = require('./parse-release-body.cjs')
+const { renderMarkdown, mergePreserving } = require('./render-markdown.cjs')
+
+function fileNameFor(sdk, language, version) {
+  if (sdk === 'evals') return `evals/v${version}.md`
+  return `harness/${language}-v${version}.md`
+}
+
+/**
+ * @param {string} repo  the SOURCE repo the release belongs to
+ * @param {{tag_name:string, published_at:string, html_url:string, body:string|null}} release
+ * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null}>, readExisting:(path:string)=>Promise<string|null>}} deps
+ * @returns {Promise<{path:string, contents:string, warning?:string}|null>}
+ */
+async function buildReleaseFile(repo, release, deps) {
+  const meta = tagToMeta(repo, release.tag_name)
+  if (!meta) return null
+
+  const parsed = parseReleaseBody(release.body)
+
+  // Format-drift guard: if the body clearly has changelog bullets but few/none
+  // parsed, the format likely changed (or notes are hand-written). Don't fail —
+  // emit the file (still links the release) and attach a warning for the PR.
+  const bullets = countChangelogBullets(release.body)
+  const warning =
+    bullets >= 3 && parsed.length < bullets * 0.8
+      ? `${release.tag_name}: parsed ${parsed.length} of ${bullets} changelog bullets — release-note format may have changed; review before merge.`
+      : undefined
+
+  const entries = []
+  for (const p of parsed) {
+    const prRepo = p.prRepo || repo
+    const enr = p.pr
+      ? await deps.enrich(prRepo, p.pr)
+      : { areas: [], breaking: false, commit: null, author: null }
+    const breaking = p.breaking || enr.breaking
+    entries.push({
+      type: breaking && p.type === 'other' ? 'breaking' : p.type,
+      breaking,
+      scope: p.scope,
+      areas: enr.areas,
+      title: p.title,
+      pr: p.pr,
+      prUrl: p.pr ? `https://github.com/${prRepo}/pull/${p.pr}` : null,
+      commit: enr.commit,
+      commitUrl: enr.commit ? `https://github.com/${prRepo}/commit/${enr.commit}` : null,
+      author: enr.author || p.author,
+    })
+  }
+
+  const file = {
+    sdk: meta.sdk,
+    language: meta.language,
+    version: meta.version,
+    tag: release.tag_name,
+    date: release.published_at.slice(0, 10),
+    releaseUrl: release.html_url,
+    packageUrl: getPackageUrl(meta.sdk, meta.language, meta.version),
+    entries,
+  }
+
+  const path = `site/src/content/changelog/${fileNameFor(meta.sdk, meta.language, meta.version)}`
+  const existing = await deps.readExisting(path)
+  const contents = existing ? mergePreserving(file, existing) : renderMarkdown(file)
+  return warning ? { path, contents, warning } : { path, contents }
+}
+
+module.exports = { buildReleaseFile }

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -46,16 +46,15 @@ async function buildReleaseFile(repo, release, deps) {
   // 2. Language (monorepo prefixed tags only): those releases list every merged
   //    PR regardless of language, so gate by which SDK dirs the PR touched —
   //    python stream keeps python-touching PRs, ts keeps ts-touching, both →
-  //    both. Unknown file info → kept (degrade open). Pre-monorepo bare-`v` and
-  //    evals are single-language, so no language gate there.
+  //    both. Unknown file info → kept (degrade open).
   //
-  //    CRUCIAL: the dir-based language signal (strands-py/ vs strands-ts/) only
-  //    exists in the monorepo repo itself. Some early python releases were
-  //    re-tagged `python/v*` but their PRs live in the OLD flat `sdk-python`
-  //    repo (code under `src/`, no strands-py/ dir). Gating those by dir would
-  //    see empty languages and wrongly drop EVERY entry, emptying the release.
-  //    So only language-gate a PR when it actually lives in this release's repo
-  //    (prRepo === repo); cross-repo PRs are single-language by provenance.
+  //    CRUCIAL: only gate when the PR has a POSITIVE dir signal — i.e. it
+  //    touches strands-py/ and/or strands-ts/. A PR with EMPTY languages
+  //    (touches neither: root config/CI, or a pre-monorepo flat-layout PR whose
+  //    code lived under src/ before the strands-py/ dir existed) must be KEPT,
+  //    not dropped. Gating on empty languages would wrongly empty pre-monorepo
+  //    releases whose tags were re-applied as python/v* in the monorepo.
+  //    Pre-monorepo bare-`v` and evals are single-language: no language gate.
   const isMonorepoStream =
     meta.sdk === 'harness' &&
     (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
@@ -67,7 +66,7 @@ async function buildReleaseFile(repo, release, deps) {
       ? await deps.enrich(prRepo, p.pr)
       : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
     if (enr.docsOnly) continue
-    if (isMonorepoStream && prRepo === repo && Array.isArray(enr.languages) && !enr.languages.includes(meta.language)) {
+    if (isMonorepoStream && Array.isArray(enr.languages) && enr.languages.length > 0 && !enr.languages.includes(meta.language)) {
       continue
     }
     const breaking = p.breaking || enr.breaking
@@ -100,16 +99,14 @@ async function buildReleaseFile(repo, release, deps) {
     const prRepo = c.prRepo || repo
     const enr = await deps.enrich(prRepo, c.pr)
     if (enr.docsOnly) continue
-    // Only language-gate PRs from the monorepo repo itself (see the entries
-    // gate above — cross-repo PRs have no strands-py/strands-ts dir signal).
-    if (isMonorepoStream && prRepo === repo) {
-      const langs = enr.languages
-      if (!Array.isArray(langs) || langs.length === 0 || langs.includes(meta.language)) {
-        newContributors.push(c)
-      }
-    } else {
-      newContributors.push(c)
+    // Mirror the entries gate: only drop when the PR has a positive dir signal
+    // for the OTHER language. Empty/unknown languages (no dir signal, or a
+    // first PR touching only root/ci) are kept — people aren't noise.
+    const langs = enr.languages
+    if (isMonorepoStream && Array.isArray(langs) && langs.length > 0 && !langs.includes(meta.language)) {
+      continue
     }
+    newContributors.push(c)
   }
 
   const file = {

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -83,7 +83,9 @@ async function buildReleaseFile(repo, release, deps) {
   if (isMonorepoStream) {
     const gated = []
     for (const c of newContributors) {
-      const enr = await deps.enrich(repo, c.pr)
+      // Use the PR's own repo (mirrors the entries path) — first-contribution
+      // links can point at the pre-monorepo repos.
+      const enr = await deps.enrich(c.prRepo || repo, c.pr)
       const langs = enr.languages
       if (!Array.isArray(langs) || langs.length === 0 || langs.includes(meta.language)) {
         gated.push(c)

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -2,7 +2,7 @@
 // injected deps (enrich + readExisting), so it's unit-testable without network.
 
 const { tagToMeta, getPackageUrl } = require('./tag-meta.cjs')
-const { parseReleaseBody, countChangelogBullets, parseNewContributors } = require('./parse-release-body.cjs')
+const { parseNewContributors } = require('./parse-release-body.cjs')
 const { renderMarkdown, mergePreserving } = require('./render-markdown.cjs')
 
 function fileNameFor(sdk, language, version) {
@@ -13,7 +13,7 @@ function fileNameFor(sdk, language, version) {
 /**
  * @param {string} repo  the SOURCE repo the release belongs to
  * @param {{tag_name:string, published_at:string, html_url:string, body:string|null}} release
- * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null,languages:string[]|null,docsOnly:boolean}>, readExisting:(path:string)=>Promise<string|null>, skipExisting?:boolean}} deps
+ * @param {{deriveEntries:(repo:string,release:object)=>Promise<{entries:Array,warning?:string}>, enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null,languages:string[]|null,docsOnly:boolean}>, readExisting:(path:string)=>Promise<string|null>, skipExisting?:boolean}} deps
  * @returns {Promise<{path:string, contents:string, warning?:string}|null>}
  */
 async function buildReleaseFile(repo, release, deps) {
@@ -30,16 +30,11 @@ async function buildReleaseFile(repo, release, deps) {
   // rate-limited re-run. A full refresh is an explicit backfill dispatch.
   if (deps.skipExisting && existing) return null
 
-  const parsed = parseReleaseBody(release.body)
-
-  // Format-drift guard: if the body clearly has changelog bullets but few/none
-  // parsed, the format likely changed (or notes are hand-written). Don't fail —
-  // emit the file (still links the release) and attach a warning for the PR.
-  const bullets = countChangelogBullets(release.body)
-  const warning =
-    bullets >= 3 && parsed.length < bullets * 0.8
-      ? `${release.tag_name}: parsed ${parsed.length} of ${bullets} changelog bullets — release-note format may have changed; review before merge.`
-      : undefined
+  // Entries come from the GitHub compare API (every merged PR between the prior
+  // tag and this one) — deterministic and independent of release-note format.
+  // The release body is NOT parsed for entries; it's preserved as curated
+  // narrative via mergePreserving below.
+  const { entries: parsed, warning } = await deps.deriveEntries(repo, release)
 
   // Two gates apply to every entry:
   //

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -13,12 +13,22 @@ function fileNameFor(sdk, language, version) {
 /**
  * @param {string} repo  the SOURCE repo the release belongs to
  * @param {{tag_name:string, published_at:string, html_url:string, body:string|null}} release
- * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null}>, readExisting:(path:string)=>Promise<string|null>}} deps
+ * @param {{enrich:(prRepo:string,pr:number)=>Promise<{areas:string[],breaking:boolean,commit:string|null,author:string|null}>, readExisting:(path:string)=>Promise<string|null>, skipExisting?:boolean}} deps
  * @returns {Promise<{path:string, contents:string, warning?:string}|null>}
  */
 async function buildReleaseFile(repo, release, deps) {
   const meta = tagToMeta(repo, release.tag_name)
   if (!meta) return null
+
+  const path = `site/src/content/changelog/${fileNameFor(meta.sdk, meta.language, meta.version)}`
+  const existing = await deps.readExisting(path)
+
+  // skipExisting (used by the daily cron backstop): only generate files for
+  // releases that don't have one yet. Checked BEFORE enrichment so a skipped
+  // release costs zero PR API calls, and existing files (possibly carrying
+  // richer enrichment from when labels were fresher) are never regressed by a
+  // rate-limited re-run. A full refresh is an explicit backfill dispatch.
+  if (deps.skipExisting && existing) return null
 
   const parsed = parseReleaseBody(release.body)
 
@@ -63,8 +73,6 @@ async function buildReleaseFile(repo, release, deps) {
     entries,
   }
 
-  const path = `site/src/content/changelog/${fileNameFor(meta.sdk, meta.language, meta.version)}`
-  const existing = await deps.readExisting(path)
   const contents = existing ? mergePreserving(file, existing) : renderMarkdown(file)
   return warning ? { path, contents, warning } : { path, contents }
 }

--- a/changelog-release-pr/scripts/build-release-file.cjs
+++ b/changelog-release-pr/scripts/build-release-file.cjs
@@ -41,12 +41,26 @@ async function buildReleaseFile(repo, release, deps) {
       ? `${release.tag_name}: parsed ${parsed.length} of ${bullets} changelog bullets — release-note format may have changed; review before merge.`
       : undefined
 
-  // Monorepo releases (prefixed tags) list every merged PR regardless of
-  // language, so gate entries by which SDK dirs the PR actually touched:
-  // python stream keeps python-touching PRs, ts stream keeps ts-touching,
-  // both → both, site/ci/docs-only (empty languages) → omitted everywhere,
-  // unknown (file info unavailable) → kept (degrade open). Pre-monorepo
-  // bare-`v` tags and evals are single-language releases — no filtering.
+  // Two gates apply to every entry:
+  //
+  // 1. Docs-only (ALL streams): a PR confined to docs/blog/website dirs never
+  //    lines up with an SDK+language, so it's dropped everywhere — including
+  //    pre-monorepo bare-`v` and evals, which are otherwise unfiltered. This
+  //    keeps the changelog focused on SDK+language work (a blog-only PR or a
+  //    pure docs change won't appear in any stream).
+  // 2. Language (monorepo prefixed tags only): those releases list every merged
+  //    PR regardless of language, so gate by which SDK dirs the PR touched —
+  //    python stream keeps python-touching PRs, ts keeps ts-touching, both →
+  //    both. Unknown file info → kept (degrade open). Pre-monorepo bare-`v` and
+  //    evals are single-language, so no language gate there.
+  //
+  //    CRUCIAL: the dir-based language signal (strands-py/ vs strands-ts/) only
+  //    exists in the monorepo repo itself. Some early python releases were
+  //    re-tagged `python/v*` but their PRs live in the OLD flat `sdk-python`
+  //    repo (code under `src/`, no strands-py/ dir). Gating those by dir would
+  //    see empty languages and wrongly drop EVERY entry, emptying the release.
+  //    So only language-gate a PR when it actually lives in this release's repo
+  //    (prRepo === repo); cross-repo PRs are single-language by provenance.
   const isMonorepoStream =
     meta.sdk === 'harness' &&
     (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
@@ -56,8 +70,9 @@ async function buildReleaseFile(repo, release, deps) {
     const prRepo = p.prRepo || repo
     const enr = p.pr
       ? await deps.enrich(prRepo, p.pr)
-      : { areas: [], breaking: false, commit: null, author: null, languages: null }
-    if (isMonorepoStream && Array.isArray(enr.languages) && !enr.languages.includes(meta.language)) {
+      : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
+    if (enr.docsOnly) continue
+    if (isMonorepoStream && prRepo === repo && Array.isArray(enr.languages) && !enr.languages.includes(meta.language)) {
       continue
     }
     const breaking = p.breaking || enr.breaking
@@ -75,23 +90,31 @@ async function buildReleaseFile(repo, release, deps) {
     })
   }
 
-  // New contributors: language-gate like entries, with one deliberate
-  // difference — a first PR that touches NO sdk dir (docs/ci/site) is still
-  // celebrated in BOTH streams (entries with no language are dropped as noise;
-  // people aren't noise). Unknown file info → also kept in both.
-  let newContributors = parseNewContributors(release.body)
-  if (isMonorepoStream) {
-    const gated = []
-    for (const c of newContributors) {
-      // Use the PR's own repo (mirrors the entries path) — first-contribution
-      // links can point at the pre-monorepo repos.
-      const enr = await deps.enrich(c.prRepo || repo, c.pr)
+  // New contributors gate. A docs-only first PR (blog/site/docs) is dropped on
+  // every stream — same focus rule as entries; a blog-only contributor doesn't
+  // belong in an SDK+language changelog. Beyond that, on monorepo streams we
+  // language-gate, with one deliberate softness: a first PR that touches NO sdk
+  // dir but isn't docs-only (e.g. ci) is still celebrated in BOTH streams, and
+  // unknown file info is kept (people aren't noise). Pre-monorepo/evals streams
+  // keep everyone who isn't docs-only.
+  const rawContributors = parseNewContributors(release.body)
+  const newContributors = []
+  for (const c of rawContributors) {
+    // Use the PR's own repo (mirrors the entries path) — first-contribution
+    // links can point at the pre-monorepo repos.
+    const prRepo = c.prRepo || repo
+    const enr = await deps.enrich(prRepo, c.pr)
+    if (enr.docsOnly) continue
+    // Only language-gate PRs from the monorepo repo itself (see the entries
+    // gate above — cross-repo PRs have no strands-py/strands-ts dir signal).
+    if (isMonorepoStream && prRepo === repo) {
       const langs = enr.languages
       if (!Array.isArray(langs) || langs.length === 0 || langs.includes(meta.language)) {
-        gated.push(c)
+        newContributors.push(c)
       }
+    } else {
+      newContributors.push(c)
     }
-    newContributors = gated
   }
 
   const file = {

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -103,6 +103,37 @@ test('pre-monorepo and evals releases are not language-filtered', async () => {
   assert.match(ev.contents, /eval thing/)
 })
 
+test('new contributors are language-gated, but docs/ci-only ones appear in both streams', async () => {
+  const body = [
+    '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+    '',
+    '## New Contributors',
+    '* @pydev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/10',
+    '* @tsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/11',
+    '* @docsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/12',
+    '* @mystery made their first contribution in https://github.com/strands-agents/harness-sdk/pull/13',
+  ].join('\n')
+  const langByPr = { 1: ['python'], 10: ['python'], 11: ['typescript'], 12: [], 13: null }
+  const deps = {
+    enrich: async (_r, pr) => ({ areas: [], breaking: false, commit: null, author: null, languages: langByPr[pr] }),
+    readExisting: async () => null,
+  }
+  const py = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  // python stream: pydev (python), docsdev (neither → both), mystery (unknown → both); NOT tsdev
+  assert.match(py.contents, /login: pydev/)
+  assert.match(py.contents, /login: docsdev/)
+  assert.match(py.contents, /login: mystery/)
+  assert.doesNotMatch(py.contents, /login: tsdev/)
+
+  const ts = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'typescript/v1.5.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  assert.match(ts.contents, /login: tsdev/)
+  assert.match(ts.contents, /login: docsdev/)
+  assert.match(ts.contents, /login: mystery/)
+  assert.doesNotMatch(ts.contents, /login: pydev/)
+})
+
 test('new contributors flow into frontmatter, not entries', async () => {
   const body = [
     '* feat: real thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -103,6 +103,20 @@ test('pre-monorepo and evals releases are not language-filtered', async () => {
   assert.match(ev.contents, /eval thing/)
 })
 
+test('new contributors flow into frontmatter, not entries', async () => {
+  const body = [
+    '* feat: real thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+    '',
+    '## New Contributors',
+    '* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2700',
+  ].join('\n')
+  const r = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: ['python'] }), readExisting: async () => null })
+  assert.match(r.contents, /newContributors:\n  - \{ login: newdev, pr: 2700 \}/)
+  assert.doesNotMatch(r.contents, /first contribution/) // not an entry
+})
+
 test('breaking marker promotes type when no conventional type', async () => {
   // a non-conventional line that the PR labels mark breaking → type becomes 'breaking'
   const r = await buildReleaseFile('strands-agents/harness-sdk',

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -55,6 +55,54 @@ test('flags format-drift warning when bullets parse poorly', async () => {
   assert.match(r.warning, /parsed 0 of 3/)
 })
 
+test('monorepo release filters entries by stream language from PR files', async () => {
+  const body = [
+    '* feat: py thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+    '* feat: ts thing by @b in https://github.com/strands-agents/harness-sdk/pull/2',
+    '* feat: both thing by @c in https://github.com/strands-agents/harness-sdk/pull/3',
+    '* chore: site thing by @d in https://github.com/strands-agents/harness-sdk/pull/4',
+    '* fix: unknown thing by @e in https://github.com/strands-agents/harness-sdk/pull/5',
+  ].join('\n')
+  const langByPr = { 1: ['python'], 2: ['typescript'], 3: ['python', 'typescript'], 4: [], 5: null }
+  const deps = {
+    enrich: async (_repo, pr) => ({ areas: [], breaking: false, commit: null, author: null, languages: langByPr[pr] }),
+    readExisting: async () => null,
+  }
+  const py = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  // python stream: keeps py(1), both(3), unknown(5); drops ts(2) and site-only(4)
+  assert.match(py.contents, /py thing/)
+  assert.match(py.contents, /both thing/)
+  assert.match(py.contents, /unknown thing/)
+  assert.doesNotMatch(py.contents, /ts thing/)
+  assert.doesNotMatch(py.contents, /site thing/)
+
+  const ts = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'typescript/v1.5.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  // typescript stream: keeps ts(2), both(3), unknown(5)
+  assert.match(ts.contents, /ts thing/)
+  assert.match(ts.contents, /both thing/)
+  assert.match(ts.contents, /unknown thing/)
+  assert.doesNotMatch(ts.contents, /py thing/)
+  assert.doesNotMatch(ts.contents, /site thing/)
+})
+
+test('pre-monorepo and evals releases are not language-filtered', async () => {
+  const deps = {
+    // even if files say typescript, a single-language-repo release keeps everything
+    enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: ['typescript'] }),
+    readExisting: async () => null,
+  }
+  const old = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h',
+      body: '* feat: old thing by @a in https://github.com/strands-agents/sdk-python/pull/9' }, deps)
+  assert.match(old.contents, /old thing/)
+  const ev = await buildReleaseFile('strands-agents/evals',
+    { tag_name: 'v0.2.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h',
+      body: '* feat: eval thing by @a in https://github.com/strands-agents/evals/pull/9' }, deps)
+  assert.match(ev.contents, /eval thing/)
+})
+
 test('breaking marker promotes type when no conventional type', async () => {
   // a non-conventional line that the PR labels mark breaking → type becomes 'breaking'
   const r = await buildReleaseFile('strands-agents/harness-sdk',

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -198,6 +198,46 @@ test('docs-only first-time contributors are dropped on every stream', async () =
   assert.doesNotMatch(old.contents, /login: blogger/)
 })
 
+test('monorepo new contributor whose PR is in the OLD flat repo is not language-gated', async () => {
+  // Mirror of the entries-loop guard for the contributors loop: a python/v*
+  // release's first-contributor PR can live in sdk-python (no strands-py/ dir →
+  // languages []). It must NOT be dropped by the language gate.
+  const body = [
+    '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+    '',
+    '## New Contributors',
+    '* @earlybird made their first contribution in https://github.com/strands-agents/sdk-python/pull/900',
+  ].join('\n')
+  const deps = {
+    enrich: async (_r, pr) => pr === 900
+      ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false } // cross-repo, code-touching
+      : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
+    readExisting: async () => null,
+  }
+  const py = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  assert.match(py.contents, /login: earlybird/) // survives — cross-repo, not dir-gated
+})
+
+test('docs-only contributor is dropped even on a monorepo stream', async () => {
+  // Pins the gate ordering: docs-only check runs before the language gate.
+  const body = [
+    '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+    '',
+    '## New Contributors',
+    '* @docsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/5',
+  ].join('\n')
+  const deps = {
+    enrich: async (_r, pr) => pr === 5
+      ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+      : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
+    readExisting: async () => null,
+  }
+  const py = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
+  assert.doesNotMatch(py.contents, /login: docsdev/)
+})
+
 test('new contributors flow into frontmatter, not entries', async () => {
   const body = [
     '* feat: real thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -1,6 +1,14 @@
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
 const { buildReleaseFile } = require('./build-release-file.cjs')
+const { parseReleaseBody } = require('./parse-release-body.cjs')
+
+// buildReleaseFile now sources entries from deps.deriveEntries (compare-driven)
+// rather than parsing the release body. These tests describe the desired entry
+// set as a bullet body for readability, so this stub turns that body back into
+// the parsed-line shape deriveEntries returns — exercising the same downstream
+// enrichment + gating the real derive feeds.
+const bodyDerive = async (_repo, release) => ({ entries: parseReleaseBody(release.body), warning: undefined })
 
 const release = {
   tag_name: 'python/v1.42.0',
@@ -12,7 +20,7 @@ const release = {
 test('produces correct path + parsed/enriched contents', async () => {
   const result = await buildReleaseFile('strands-agents/harness-sdk', release, {
     enrich: async () => ({ areas: ['model'], breaking: false, commit: '155239d', author: 'yatszhash' }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   })
   assert.equal(result.path, 'site/src/content/changelog/harness/python-v1.42.0.md')
   assert.match(result.contents, /sdk: harness/)
@@ -32,7 +40,7 @@ test('evals file path + no language', async () => {
   }
   const r = await buildReleaseFile('strands-agents/evals', evalsRelease, {
     enrich: async () => ({ areas: [], breaking: false, commit: 'aaa1111', author: 'x' }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   })
   assert.equal(r.path, 'site/src/content/changelog/evals/v0.2.1.md')
   assert.doesNotMatch(r.contents, /\nlanguage:/)
@@ -41,18 +49,18 @@ test('evals file path + no language', async () => {
 test('skips out-of-scope tags', async () => {
   const r = await buildReleaseFile('strands-agents/harness-sdk',
     { ...release, tag_name: 'python-wasm/v0.0.1' },
-    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null }), readExisting: async () => null })
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null }), deriveEntries: bodyDerive, readExisting: async () => null })
   assert.equal(r, null)
 })
 
-test('flags format-drift warning when bullets parse poorly', async () => {
-  const drifted = { ...release, body: "## What's Changed\n* updated thing #11\n* fixed thing #12\n* added thing #13\n" }
-  const r = await buildReleaseFile('strands-agents/harness-sdk', drifted, {
+test('passes through a derive warning (e.g. truncated compare range)', async () => {
+  const r = await buildReleaseFile('strands-agents/harness-sdk', release, {
+    deriveEntries: async () => ({ entries: [], warning: 'python/v1.42.0: compare range exceeded 250 commits' }),
     enrich: async () => ({ areas: [], breaking: false, commit: null, author: null }),
     readExisting: async () => null,
   })
   assert.ok(r)
-  assert.match(r.warning, /parsed 0 of 3/)
+  assert.match(r.warning, /exceeded 250 commits/)
 })
 
 test('monorepo release filters entries by stream language from PR files', async () => {
@@ -66,7 +74,7 @@ test('monorepo release filters entries by stream language from PR files', async 
   const langByPr = { 1: ['python'], 2: ['typescript'], 3: ['python', 'typescript'], 4: [], 5: null }
   const deps = {
     enrich: async (_repo, pr) => ({ areas: [], breaking: false, commit: null, author: null, languages: langByPr[pr] }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const py = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
@@ -98,7 +106,7 @@ test('monorepo-tagged release with PRs in the OLD flat repo is not language-gate
   const deps = {
     // old-repo PRs touch src/ etc → languagesFromFiles yields [] (empty)
     enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const r = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body }, deps)
@@ -112,7 +120,7 @@ test('pre-monorepo and evals releases are not language-filtered', async () => {
   const deps = {
     // even if files say typescript, a single-language-repo release keeps everything
     enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: ['typescript'] }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const old = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h',
@@ -137,7 +145,7 @@ test('new contributors are language-gated, but docs/ci-only ones appear in both 
   const langByPr = { 1: ['python'], 10: ['python'], 11: ['typescript'], 12: [], 13: null }
   const deps = {
     enrich: async (_r, pr) => ({ areas: [], breaking: false, commit: null, author: null, languages: langByPr[pr] }),
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const py = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
@@ -164,7 +172,7 @@ test('docs-only PRs are dropped on every stream (incl. pre-monorepo and evals)',
     enrich: async (_r, pr) => pr === 2
       ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
       : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   // pre-monorepo bare-v (no language gate, but docs-only still drops)
   const old = await buildReleaseFile('strands-agents/harness-sdk',
@@ -175,7 +183,7 @@ test('docs-only PRs are dropped on every stream (incl. pre-monorepo and evals)',
   const ev = await buildReleaseFile('strands-agents/evals',
     { tag_name: 'v0.2.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h',
       body: '* docs: site only by @b in https://github.com/strands-agents/evals/pull/2' },
-    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }), readExisting: async () => null })
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }), deriveEntries: bodyDerive, readExisting: async () => null })
   assert.doesNotMatch(ev.contents, /site only/)
 })
 
@@ -190,7 +198,7 @@ test('docs-only first-time contributors are dropped on every stream', async () =
     enrich: async (_r, pr) => pr === 2
       ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
       : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   // pre-monorepo stream: a blog-only first contribution does NOT appear
   const old = await buildReleaseFile('strands-agents/harness-sdk',
@@ -212,7 +220,7 @@ test('monorepo new contributor whose PR is in the OLD flat repo is not language-
     enrich: async (_r, pr) => pr === 900
       ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false } // cross-repo, code-touching
       : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const py = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
@@ -231,7 +239,7 @@ test('docs-only contributor is dropped even on a monorepo stream', async () => {
     enrich: async (_r, pr) => pr === 5
       ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
       : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
-    readExisting: async () => null,
+    deriveEntries: bodyDerive, readExisting: async () => null,
   }
   const py = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
@@ -247,7 +255,7 @@ test('new contributors flow into frontmatter, not entries', async () => {
   ].join('\n')
   const r = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
-    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: ['python'] }), readExisting: async () => null })
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: ['python'] }), deriveEntries: bodyDerive, readExisting: async () => null })
   assert.match(r.contents, /newContributors:\n  - \{ login: newdev, pr: 2700 \}/)
   assert.doesNotMatch(r.contents, /first contribution/) // not an entry
 })
@@ -256,7 +264,7 @@ test('breaking marker promotes type when no conventional type', async () => {
   // a non-conventional line that the PR labels mark breaking → type becomes 'breaking'
   const r = await buildReleaseFile('strands-agents/harness-sdk',
     { ...release, body: '* drop the old api by @x in https://github.com/strands-agents/harness-sdk/pull/1\n' },
-    { enrich: async () => ({ areas: [], breaking: true, commit: 'bbb2222', author: 'x' }), readExisting: async () => null })
+    { enrich: async () => ({ areas: [], breaking: true, commit: 'bbb2222', author: 'x' }), deriveEntries: bodyDerive, readExisting: async () => null })
   assert.match(r.contents, /type: breaking/)
   assert.match(r.contents, /breaking: true/)
 })

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -1,0 +1,65 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { buildReleaseFile } = require('./build-release-file.cjs')
+
+const release = {
+  tag_name: 'python/v1.42.0',
+  published_at: '2026-06-01T18:18:57Z',
+  html_url: 'https://github.com/strands-agents/harness-sdk/releases/tag/python%2Fv1.42.0',
+  body: "## What's Changed\n* feat(model): plumb cache tokens by @yatszhash in https://github.com/strands-agents/sdk-python/pull/2287\n",
+}
+
+test('produces correct path + parsed/enriched contents', async () => {
+  const result = await buildReleaseFile('strands-agents/harness-sdk', release, {
+    enrich: async () => ({ areas: ['model'], breaking: false, commit: '155239d', author: 'yatszhash' }),
+    readExisting: async () => null,
+  })
+  assert.equal(result.path, 'site/src/content/changelog/harness/python-v1.42.0.md')
+  assert.match(result.contents, /sdk: harness/)
+  assert.match(result.contents, /title: "plumb cache tokens"/)
+  assert.match(result.contents, /areas: \[model\]/)
+  // prUrl/commitUrl use the PR's own repo (sdk-python), not harness-sdk
+  assert.match(result.contents, /sdk-python\/pull\/2287/)
+  assert.match(result.contents, /sdk-python\/commit\/155239d/)
+  assert.equal(result.warning, undefined)
+})
+
+test('evals file path + no language', async () => {
+  const evalsRelease = {
+    tag_name: 'v0.2.1', published_at: '2026-05-29T00:00:00Z',
+    html_url: 'https://github.com/strands-agents/evals/releases/tag/v0.2.1',
+    body: '* feat: add chaos testing by @x in https://github.com/strands-agents/evals/pull/224\n',
+  }
+  const r = await buildReleaseFile('strands-agents/evals', evalsRelease, {
+    enrich: async () => ({ areas: [], breaking: false, commit: 'aaa1111', author: 'x' }),
+    readExisting: async () => null,
+  })
+  assert.equal(r.path, 'site/src/content/changelog/evals/v0.2.1.md')
+  assert.doesNotMatch(r.contents, /\nlanguage:/)
+})
+
+test('skips out-of-scope tags', async () => {
+  const r = await buildReleaseFile('strands-agents/harness-sdk',
+    { ...release, tag_name: 'python-wasm/v0.0.1' },
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null }), readExisting: async () => null })
+  assert.equal(r, null)
+})
+
+test('flags format-drift warning when bullets parse poorly', async () => {
+  const drifted = { ...release, body: "## What's Changed\n* updated thing #11\n* fixed thing #12\n* added thing #13\n" }
+  const r = await buildReleaseFile('strands-agents/harness-sdk', drifted, {
+    enrich: async () => ({ areas: [], breaking: false, commit: null, author: null }),
+    readExisting: async () => null,
+  })
+  assert.ok(r)
+  assert.match(r.warning, /parsed 0 of 3/)
+})
+
+test('breaking marker promotes type when no conventional type', async () => {
+  // a non-conventional line that the PR labels mark breaking → type becomes 'breaking'
+  const r = await buildReleaseFile('strands-agents/harness-sdk',
+    { ...release, body: '* drop the old api by @x in https://github.com/strands-agents/harness-sdk/pull/1\n' },
+    { enrich: async () => ({ areas: [], breaking: true, commit: 'bbb2222', author: 'x' }), readExisting: async () => null })
+  assert.match(r.contents, /type: breaking/)
+  assert.match(r.contents, /breaking: true/)
+})

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -87,6 +87,27 @@ test('monorepo release filters entries by stream language from PR files', async 
   assert.doesNotMatch(ts.contents, /site thing/)
 })
 
+test('monorepo-tagged release with PRs in the OLD flat repo is not language-gated', async () => {
+  // Early python releases were re-tagged `python/v*` but their PRs live in the
+  // old `sdk-python` repo (code under `src/`, no strands-py/ dir). The file
+  // signal there is empty languages — gating on it would empty the release.
+  const body = [
+    '* feat: real py feature by @a in https://github.com/strands-agents/sdk-python/pull/423',
+    '* fix: another py fix by @b in https://github.com/strands-agents/sdk-python/pull/429',
+  ].join('\n')
+  const deps = {
+    // old-repo PRs touch src/ etc → languagesFromFiles yields [] (empty)
+    enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false }),
+    readExisting: async () => null,
+  }
+  const r = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'python/v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body }, deps)
+  // Both entries must survive — the cross-repo PRs are python by provenance,
+  // not gated by the (nonexistent) monorepo dir signal.
+  assert.match(r.contents, /real py feature/)
+  assert.match(r.contents, /another py fix/)
+})
+
 test('pre-monorepo and evals releases are not language-filtered', async () => {
   const deps = {
     // even if files say typescript, a single-language-repo release keeps everything
@@ -132,6 +153,49 @@ test('new contributors are language-gated, but docs/ci-only ones appear in both 
   assert.match(ts.contents, /login: docsdev/)
   assert.match(ts.contents, /login: mystery/)
   assert.doesNotMatch(ts.contents, /login: pydev/)
+})
+
+test('docs-only PRs are dropped on every stream (incl. pre-monorepo and evals)', async () => {
+  const body = [
+    '* feat: real code by @a in https://github.com/strands-agents/sdk-python/pull/1',
+    '* docs: blog post by @b in https://github.com/strands-agents/sdk-python/pull/2',
+  ].join('\n')
+  const deps = {
+    enrich: async (_r, pr) => pr === 2
+      ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+      : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
+    readExisting: async () => null,
+  }
+  // pre-monorepo bare-v (no language gate, but docs-only still drops)
+  const old = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body }, deps)
+  assert.match(old.contents, /real code/)
+  assert.doesNotMatch(old.contents, /blog post/)
+  // evals (no language gate either)
+  const ev = await buildReleaseFile('strands-agents/evals',
+    { tag_name: 'v0.2.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h',
+      body: '* docs: site only by @b in https://github.com/strands-agents/evals/pull/2' },
+    { enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }), readExisting: async () => null })
+  assert.doesNotMatch(ev.contents, /site only/)
+})
+
+test('docs-only first-time contributors are dropped on every stream', async () => {
+  const body = [
+    '* feat: x by @a in https://github.com/strands-agents/sdk-python/pull/1',
+    '',
+    '## New Contributors',
+    '* @blogger made their first contribution in https://github.com/strands-agents/sdk-python/pull/2',
+  ].join('\n')
+  const deps = {
+    enrich: async (_r, pr) => pr === 2
+      ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+      : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
+    readExisting: async () => null,
+  }
+  // pre-monorepo stream: a blog-only first contribution does NOT appear
+  const old = await buildReleaseFile('strands-agents/harness-sdk',
+    { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body }, deps)
+  assert.doesNotMatch(old.contents, /login: blogger/)
 })
 
 test('new contributors flow into frontmatter, not entries', async () => {

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -1,14 +1,22 @@
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
 const { buildReleaseFile } = require('./build-release-file.cjs')
-const { parseReleaseBody } = require('./parse-release-body.cjs')
+const { classifyTitle } = require('./parse-release-body.cjs')
 
-// buildReleaseFile now sources entries from deps.deriveEntries (compare-driven)
-// rather than parsing the release body. These tests describe the desired entry
-// set as a bullet body for readability, so this stub turns that body back into
-// the parsed-line shape deriveEntries returns — exercising the same downstream
-// enrichment + gating the real derive feeds.
-const bodyDerive = async (_repo, release) => ({ entries: parseReleaseBody(release.body), warning: undefined })
+// buildReleaseFile sources entries from deps.deriveEntries (compare-driven), not
+// from the release body. These tests describe the desired entry set as a bullet
+// body for readability; this local helper turns that bullet body into the
+// parsed-line shape deriveEntries returns, so the tests exercise the same
+// downstream enrichment + gating the real derive feeds. (It is NOT the
+// production path — that reads the compare API.)
+const BULLET = /^\s*[-*]\s+(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/
+const parseBulletBody = (body) =>
+  String(body || '')
+    .split('\n')
+    .map((line) => line.match(BULLET))
+    .filter((m) => m && !/made their first contribution/.test(m[0]))
+    .map((m) => ({ ...classifyTitle(m[1]), author: m[2] || null, pr: Number(m[4]), prRepo: m[3] }))
+const bodyDerive = async (_repo, release) => ({ entries: parseBulletBody(release.body), warning: undefined })
 
 const release = {
   tag_name: 'python/v1.42.0',

--- a/changelog-release-pr/scripts/build-release-file.test.cjs
+++ b/changelog-release-pr/scripts/build-release-file.test.cjs
@@ -68,9 +68,11 @@ test('monorepo release filters entries by stream language from PR files', async 
     '* feat: py thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',
     '* feat: ts thing by @b in https://github.com/strands-agents/harness-sdk/pull/2',
     '* feat: both thing by @c in https://github.com/strands-agents/harness-sdk/pull/3',
-    '* chore: site thing by @d in https://github.com/strands-agents/harness-sdk/pull/4',
+    '* chore: neither-dir thing by @d in https://github.com/strands-agents/harness-sdk/pull/4',
     '* fix: unknown thing by @e in https://github.com/strands-agents/harness-sdk/pull/5',
   ].join('\n')
+  // 4 = empty languages (touches neither SDK dir — e.g. root/ci, or a flat-layout
+  // pre-monorepo PR). 5 = unknown (files unavailable).
   const langByPr = { 1: ['python'], 2: ['typescript'], 3: ['python', 'typescript'], 4: [], 5: null }
   const deps = {
     enrich: async (_repo, pr) => ({ areas: [], breaking: false, commit: null, author: null, languages: langByPr[pr] }),
@@ -78,19 +80,22 @@ test('monorepo release filters entries by stream language from PR files', async 
   }
   const py = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
-  // python stream: keeps py(1), both(3), unknown(5); drops ts(2) and site-only(4)
+  // python stream keeps py(1), both(3); drops ts(2). Empty-languages(4) and
+  // unknown(5) are KEPT — only a POSITIVE other-language signal drops a PR.
   assert.match(py.contents, /py thing/)
   assert.match(py.contents, /both thing/)
+  assert.match(py.contents, /neither-dir thing/)
   assert.match(py.contents, /unknown thing/)
   assert.doesNotMatch(py.contents, /ts thing/)
-  assert.doesNotMatch(py.contents, /site thing/)
 
   const ts = await buildReleaseFile('strands-agents/harness-sdk',
     { tag_name: 'typescript/v1.5.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body }, deps)
-  // typescript stream: keeps ts(2), both(3), unknown(5)
+  // typescript stream: keeps ts(2), both(3), neither-dir(4), unknown(5); drops py(1)
   assert.match(ts.contents, /ts thing/)
   assert.match(ts.contents, /both thing/)
+  assert.match(ts.contents, /neither-dir thing/)
   assert.match(ts.contents, /unknown thing/)
+  assert.doesNotMatch(ts.contents, /py thing/)
   assert.doesNotMatch(ts.contents, /py thing/)
   assert.doesNotMatch(ts.contents, /site thing/)
 })

--- a/changelog-release-pr/scripts/derive-entries.cjs
+++ b/changelog-release-pr/scripts/derive-entries.cjs
@@ -1,0 +1,79 @@
+// Derive a release's changelog entries deterministically from the GitHub
+// compare API instead of parsing the release-notes body. The compare endpoint
+// lists every merged commit between two tags regardless of how the notes are
+// written, so the breakdown is immune to release-note format drift. Each
+// commit is resolved to its PR via the commit->PR API for authoritative
+// association (handles squash and merge-commit repos), then classified with the
+// shared conventional-commit logic. Pure given an injected client.
+
+const { classifyTitle } = require('./parse-release-body.cjs')
+const { tagToMeta } = require('./tag-meta.cjs')
+const { compareVersionDesc } = require('./semver-compare.cjs')
+
+/**
+ * The previous tag in the same stream (same sdk + language) as `tag`, or null
+ * if `tag` is the first release in its stream. Streams: python/v*, typescript/v*
+ * (harness), and bare v* (evals / pre-monorepo). Uses tagToMeta to classify and
+ * compareVersionDesc to order.
+ * @returns {Promise<string|null>}
+ */
+async function previousTagInStream(repo, tag, client) {
+  const meta = tagToMeta(repo, tag)
+  if (!meta) return null
+  const tags = (await client.listTags(repo)) || []
+  // Same-stream tags, excluding `tag` itself, sorted newest-first.
+  const stream = tags
+    .map((t) => t.name)
+    .filter((name) => {
+      if (name === tag) return false
+      const m = tagToMeta(repo, name)
+      return m && m.sdk === meta.sdk && m.language === meta.language
+    })
+    .sort((a, b) => compareVersionDesc(tagToMeta(repo, a).version, tagToMeta(repo, b).version))
+  // The immediate predecessor is the newest tag older than `tag`.
+  for (const name of stream) {
+    if (compareVersionDesc(meta.version, tagToMeta(repo, name).version) < 0) {
+      // `meta` is newer than `name` (compareVersionDesc<0 means first is newer)
+      return name
+    }
+  }
+  return null
+}
+
+/**
+ * Derive parsed-line entries (the shape parseReleaseBody returns) for the range
+ * base..head in `repo`. Resolves each commit to its PR(s); a commit with no
+ * associated PR (direct push) is skipped. Memoizes commit->PR lookups.
+ *
+ * @param {{repo:string, base:string|null, head:string,
+ *   client:{compareCommits:(repo,base,head)=>Promise<{commits:Array,truncated?:boolean}>,
+ *           commitPulls:(repo,sha)=>Promise<Array>}}} opts
+ * @returns {Promise<{entries:Array, truncated:boolean, warning?:string}>}
+ */
+async function deriveEntries({ repo, base, head, client }) {
+  if (!base) {
+    // First release in the stream — no prior tag to diff against. Don't guess
+    // the whole history; emit nothing and let the caller note it.
+    return { entries: [], truncated: false, warning: `${head}: no prior tag in stream — entries not derived from compare.` }
+  }
+  const cmp = (await client.compareCommits(repo, base, head)) || { commits: [] }
+  const commits = cmp.commits || []
+  const seen = new Set()
+  const entries = []
+  for (const c of commits) {
+    const pulls = (await client.commitPulls(repo, c.sha)) || []
+    for (const pr of pulls) {
+      if (seen.has(pr.number)) continue // a PR can map to multiple commits
+      seen.add(pr.number)
+      entries.push({ ...classifyTitle(pr.title || ''), author: pr.user || null, pr: pr.number, prRepo: repo })
+    }
+  }
+  const truncated = cmp.truncated === true
+  return {
+    entries,
+    truncated,
+    warning: truncated ? `${head}: compare range exceeded GitHub's 250-commit cap — entry list may be incomplete; review before merge.` : undefined,
+  }
+}
+
+module.exports = { deriveEntries, previousTagInStream }

--- a/changelog-release-pr/scripts/derive-entries.test.cjs
+++ b/changelog-release-pr/scripts/derive-entries.test.cjs
@@ -58,6 +58,19 @@ test('truncated compare range yields a warning', async () => {
   assert.match(warning, /250-commit cap/)
 })
 
+test('processes every commit in a large (paginated) range — no downstream cap', async () => {
+  // The client paginates compare; deriveEntries must emit an entry for each of
+  // the >100 commits it returns (guards against a regression to first-page-only).
+  const N = 230
+  const commits = Array.from({ length: N }, (_, i) => ({ sha: `s${i}` }))
+  const client = {
+    compareCommits: async () => ({ commits, truncated: false }),
+    commitPulls: async (_r, sha) => [{ number: Number(sha.slice(1)) + 1, title: `feat: c${sha}`, user: 'a' }],
+  }
+  const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client })
+  assert.equal(entries.length, N)
+})
+
 // --- previousTagInStream -----------------------------------------------------
 
 const harnessTags = (names) => ({ listTags: async () => names.map((name) => ({ name })) })

--- a/changelog-release-pr/scripts/derive-entries.test.cjs
+++ b/changelog-release-pr/scripts/derive-entries.test.cjs
@@ -1,0 +1,94 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { deriveEntries, previousTagInStream } = require('./derive-entries.cjs')
+
+// --- deriveEntries -----------------------------------------------------------
+
+test('derives parsed-line entries from compare commits via commit->PR', async () => {
+  const client = {
+    compareCommits: async () => ({
+      commits: [{ sha: 'a1' }, { sha: 'b2' }],
+      truncated: false,
+    }),
+    commitPulls: async (_repo, sha) =>
+      sha === 'a1'
+        ? [{ number: 1799, title: 'feat(model): add service_tier', user: 'pgrayy' }]
+        : [{ number: 2087, title: 'fix: enforce user-first message', user: 'lizradway' }],
+  }
+  const { entries, truncated } = await deriveEntries({ repo: 'strands-agents/harness-sdk', base: 'python/v1.34.1', head: 'python/v1.35.0', client })
+  assert.equal(truncated, false)
+  assert.deepEqual(entries, [
+    { type: 'feat', scope: 'model', breaking: false, title: 'add service_tier', author: 'pgrayy', pr: 1799, prRepo: 'strands-agents/harness-sdk' },
+    { type: 'fix', scope: null, breaking: false, title: 'enforce user-first message', author: 'lizradway', pr: 2087, prRepo: 'strands-agents/harness-sdk' },
+  ])
+})
+
+test('dedups a PR that spans multiple commits', async () => {
+  const client = {
+    compareCommits: async () => ({ commits: [{ sha: 'a1' }, { sha: 'a2' }], truncated: false }),
+    commitPulls: async () => [{ number: 500, title: 'feat: x', user: 'a' }], // same PR on both commits
+  }
+  const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client })
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].pr, 500)
+})
+
+test('skips commits with no associated PR (direct push)', async () => {
+  const client = {
+    compareCommits: async () => ({ commits: [{ sha: 'a1' }, { sha: 'a2' }], truncated: false }),
+    commitPulls: async (_r, sha) => (sha === 'a1' ? [{ number: 7, title: 'fix: y', user: 'b' }] : []),
+  }
+  const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client })
+  assert.deepEqual(entries.map((e) => e.pr), [7])
+})
+
+test('no prior tag → no entries, with a warning', async () => {
+  const { entries, warning } = await deriveEntries({ repo: 'r', base: null, head: 'v0.1.0', client: {} })
+  assert.deepEqual(entries, [])
+  assert.match(warning, /no prior tag/)
+})
+
+test('truncated compare range yields a warning', async () => {
+  const client = {
+    compareCommits: async () => ({ commits: [{ sha: 'a1' }], truncated: true }),
+    commitPulls: async () => [{ number: 1, title: 'feat: z', user: 'c' }],
+  }
+  const { truncated, warning } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client })
+  assert.equal(truncated, true)
+  assert.match(warning, /250-commit cap/)
+})
+
+// --- previousTagInStream -----------------------------------------------------
+
+const harnessTags = (names) => ({ listTags: async () => names.map((name) => ({ name })) })
+
+test('finds the immediate predecessor in the python stream', async () => {
+  const client = harnessTags(['python/v1.36.0', 'python/v1.35.0', 'python/v1.34.1', 'typescript/v1.5.0', 'python/v1.34.0'])
+  const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.35.0', client)
+  assert.equal(prior, 'python/v1.34.1')
+})
+
+test('ignores tags from other streams', async () => {
+  // typescript tags must not be chosen as the prior for a python release
+  const client = harnessTags(['typescript/v1.9.0', 'python/v1.20.0', 'typescript/v1.8.0'])
+  const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.21.0', client)
+  assert.equal(prior, 'python/v1.20.0')
+})
+
+test('orders numerically, not lexically (v1.9.0 precedes v1.10.0)', async () => {
+  const client = harnessTags(['python/v1.10.0', 'python/v1.9.0', 'python/v1.8.0'])
+  const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.10.0', client)
+  assert.equal(prior, 'python/v1.9.0')
+})
+
+test('returns null for the first release in a stream', async () => {
+  const client = harnessTags(['python/v1.0.0', 'typescript/v0.5.0'])
+  const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.0.0', client)
+  assert.equal(prior, null)
+})
+
+test('evals bare-v stream resolves its own predecessor', async () => {
+  const client = { listTags: async () => ['v0.2.0', 'v0.1.17', 'v0.1.16'].map((name) => ({ name })) }
+  const prior = await previousTagInStream('strands-agents/evals', 'v0.2.0', client)
+  assert.equal(prior, 'v0.1.17')
+})

--- a/changelog-release-pr/scripts/enrich.cjs
+++ b/changelog-release-pr/scripts/enrich.cjs
@@ -49,4 +49,4 @@ async function enrichFromPr(repo, num, fetcher) {
   return { areas, breaking, commit, author: pr.user || null, languages: languagesFromFiles(pr.files) }
 }
 
-module.exports = { enrichFromPr, languagesFromFiles }
+module.exports = { enrichFromPr }

--- a/changelog-release-pr/scripts/enrich.cjs
+++ b/changelog-release-pr/scripts/enrich.cjs
@@ -17,6 +17,12 @@ const LANGUAGE_DIRS = {
   'strands-ts': 'typescript',
 }
 
+// Top-level dirs holding docs/blog/website content rather than SDK code.
+// `site/` is the monorepo home for all docs+blog+website; `docs/` is the
+// pre-monorepo / evals docs tree. A PR confined to these never lines up with
+// an SDK+language, so it's dropped on every stream (see build-release-file).
+const DOCS_DIRS = new Set(['site', 'docs'])
+
 /**
  * Derive SDK languages from changed-file paths. Returns:
  * - string[] of languages (possibly empty = site/ci/docs-only PR)
@@ -33,20 +39,36 @@ function languagesFromFiles(files) {
 }
 
 /**
+ * True when every changed file lives under a docs/website dir — i.e. a
+ * docs/blog/site-only PR. Unknown (null) or empty file lists are NOT docs-only
+ * (we don't drop on missing info). A PR touching docs AND code is not docs-only.
+ */
+function docsOnlyFromFiles(files) {
+  if (!Array.isArray(files) || files.length === 0) return false
+  return files.every((f) => DOCS_DIRS.has(String(f).split('/')[0]))
+}
+
+/**
  * @param {string} repo
  * @param {number} num
  * @param {PrFetcher} fetcher
- * @returns {Promise<{areas:string[], breaking:boolean, commit:string|null, author:string|null, languages:string[]|null}>}
+ * @returns {Promise<{areas:string[], breaking:boolean, commit:string|null, author:string|null, languages:string[]|null, docsOnly:boolean}>}
  */
 async function enrichFromPr(repo, num, fetcher) {
   const pr = await fetcher(repo, num)
-  if (!pr) return { areas: [], breaking: false, commit: null, author: null, languages: null }
+  // Unfetchable PR (deleted / rate-limited): degrade open — keep the entry,
+  // languages unknown, not docs-only (explicit, not relying on falsy undefined).
+  if (!pr) return { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
   const areas = (pr.labels || [])
     .filter((l) => l.startsWith('area-'))
     .map((l) => l.slice('area-'.length))
   const breaking = (pr.labels || []).some((l) => l.toLowerCase() === 'breaking change')
   const commit = pr.merge_commit_sha ? pr.merge_commit_sha.slice(0, 7) : null
-  return { areas, breaking, commit, author: pr.user || null, languages: languagesFromFiles(pr.files) }
+  return {
+    areas, breaking, commit, author: pr.user || null,
+    languages: languagesFromFiles(pr.files),
+    docsOnly: docsOnlyFromFiles(pr.files),
+  }
 }
 
 module.exports = { enrichFromPr }

--- a/changelog-release-pr/scripts/enrich.cjs
+++ b/changelog-release-pr/scripts/enrich.cjs
@@ -1,0 +1,29 @@
+// Enrich a parsed line from its linked PR: area-* labels, breaking flag,
+// short merge-commit SHA, author. Pure given an injected fetcher (no network
+// here), so it's unit-testable. Degrades to empty enrichment when the PR can't
+// be fetched (deleted PR, missing permissions, old repo) — callers still emit
+// the entry, just without areas/commit.
+
+/**
+ * @typedef {{labels:string[], merge_commit_sha:string|null, user:string|null}} PrData
+ * @typedef {(repo:string, num:number)=>Promise<PrData|null>} PrFetcher
+ */
+
+/**
+ * @param {string} repo
+ * @param {number} num
+ * @param {PrFetcher} fetcher
+ * @returns {Promise<{areas:string[], breaking:boolean, commit:string|null, author:string|null}>}
+ */
+async function enrichFromPr(repo, num, fetcher) {
+  const pr = await fetcher(repo, num)
+  if (!pr) return { areas: [], breaking: false, commit: null, author: null }
+  const areas = (pr.labels || [])
+    .filter((l) => l.startsWith('area-'))
+    .map((l) => l.slice('area-'.length))
+  const breaking = (pr.labels || []).some((l) => l.toLowerCase() === 'breaking change')
+  const commit = pr.merge_commit_sha ? pr.merge_commit_sha.slice(0, 7) : null
+  return { areas, breaking, commit, author: pr.user || null }
+}
+
+module.exports = { enrichFromPr }

--- a/changelog-release-pr/scripts/enrich.cjs
+++ b/changelog-release-pr/scripts/enrich.cjs
@@ -1,29 +1,52 @@
 // Enrich a parsed line from its linked PR: area-* labels, breaking flag,
-// short merge-commit SHA, author. Pure given an injected fetcher (no network
+// short merge-commit SHA, author, and (for monorepo PRs) which SDK languages
+// the PR actually touches — derived from changed-file paths because language
+// labels are too sparse to rely on. Pure given an injected fetcher (no network
 // here), so it's unit-testable. Degrades to empty enrichment when the PR can't
 // be fetched (deleted PR, missing permissions, old repo) — callers still emit
-// the entry, just without areas/commit.
+// the entry, just without areas/commit, and with languages unknown.
 
 /**
- * @typedef {{labels:string[], merge_commit_sha:string|null, user:string|null}} PrData
+ * @typedef {{labels:string[], merge_commit_sha:string|null, user:string|null, files?:string[]}} PrData
  * @typedef {(repo:string, num:number)=>Promise<PrData|null>} PrFetcher
  */
+
+// Monorepo top-level dirs that mark a PR as touching an SDK language.
+const LANGUAGE_DIRS = {
+  'strands-py': 'python',
+  'strands-ts': 'typescript',
+}
+
+/**
+ * Derive SDK languages from changed-file paths. Returns:
+ * - string[] of languages (possibly empty = site/ci/docs-only PR)
+ * - null when file info is unavailable (unknown — callers should not filter)
+ */
+function languagesFromFiles(files) {
+  if (!Array.isArray(files)) return null
+  const langs = new Set()
+  for (const f of files) {
+    const top = String(f).split('/')[0]
+    if (LANGUAGE_DIRS[top]) langs.add(LANGUAGE_DIRS[top])
+  }
+  return [...langs]
+}
 
 /**
  * @param {string} repo
  * @param {number} num
  * @param {PrFetcher} fetcher
- * @returns {Promise<{areas:string[], breaking:boolean, commit:string|null, author:string|null}>}
+ * @returns {Promise<{areas:string[], breaking:boolean, commit:string|null, author:string|null, languages:string[]|null}>}
  */
 async function enrichFromPr(repo, num, fetcher) {
   const pr = await fetcher(repo, num)
-  if (!pr) return { areas: [], breaking: false, commit: null, author: null }
+  if (!pr) return { areas: [], breaking: false, commit: null, author: null, languages: null }
   const areas = (pr.labels || [])
     .filter((l) => l.startsWith('area-'))
     .map((l) => l.slice('area-'.length))
   const breaking = (pr.labels || []).some((l) => l.toLowerCase() === 'breaking change')
   const commit = pr.merge_commit_sha ? pr.merge_commit_sha.slice(0, 7) : null
-  return { areas, breaking, commit, author: pr.user || null }
+  return { areas, breaking, commit, author: pr.user || null, languages: languagesFromFiles(pr.files) }
 }
 
-module.exports = { enrichFromPr }
+module.exports = { enrichFromPr, languagesFromFiles }

--- a/changelog-release-pr/scripts/enrich.cjs
+++ b/changelog-release-pr/scripts/enrich.cjs
@@ -23,6 +23,25 @@ const LANGUAGE_DIRS = {
 // an SDK+language, so it's dropped on every stream (see build-release-file).
 const DOCS_DIRS = new Set(['site', 'docs'])
 
+// A changed path is "docs" if it's under a docs dir OR is a top-level docs file
+// — a repo-root Markdown file (README.md, AGENTS.md, …) or a well-known root doc
+// regardless of extension (CONTRIBUTING, CHANGELOG, NOTICE, LICENSE, …). These
+// carry no SDK+language surface, so a PR confined to them is docs-only.
+const ROOT_DOC_NAMES = new Set([
+  'readme', 'contributing', 'changelog', 'notice', 'license', 'security',
+  'code_of_conduct', 'maintainers', 'authors', 'codeowners',
+])
+function isDocPath(f) {
+  const p = String(f)
+  const segs = p.split('/')
+  if (DOCS_DIRS.has(segs[0])) return true
+  if (segs.length > 1) return false // nested under a non-docs dir → code-ish
+  // top-level file: any markdown, or a known root doc by basename
+  if (/\.mdx?$/i.test(p)) return true
+  const base = p.replace(/\.[^.]*$/, '').toLowerCase()
+  return ROOT_DOC_NAMES.has(base)
+}
+
 /**
  * Derive SDK languages from changed-file paths. Returns:
  * - string[] of languages (possibly empty = site/ci/docs-only PR)
@@ -45,7 +64,7 @@ function languagesFromFiles(files) {
  */
 function docsOnlyFromFiles(files) {
   if (!Array.isArray(files) || files.length === 0) return false
-  return files.every((f) => DOCS_DIRS.has(String(f).split('/')[0]))
+  return files.every(isDocPath)
 }
 
 /**

--- a/changelog-release-pr/scripts/enrich.test.cjs
+++ b/changelog-release-pr/scripts/enrich.test.cjs
@@ -50,6 +50,25 @@ test('docsOnly false on unknown or empty file info (do not drop)', async () => {
   assert.equal(empty.docsOnly, false)
 })
 
+test('docsOnly true for top-level doc files (README, AGENTS.md, CONTRIBUTING)', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: ['README.md', 'AGENTS.md', 'CONTRIBUTING'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.docsOnly, true)
+})
+
+test('docsOnly false when a root doc PR also touches code', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: ['README.md', 'strands-py/src/agent.py'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.docsOnly, false)
+})
+
+test('docsOnly false for a top-level non-doc file (e.g. pyproject.toml)', async () => {
+  // A root config/build file is not docs — don't drop a release-affecting change.
+  const f = async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: ['pyproject.toml'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.docsOnly, false)
+})
+
 test('no merge sha yields null commit', async () => {
   const f = async () => ({ labels: [], merge_commit_sha: null, user: null })
   const e = await enrichFromPr('r', 1, f)

--- a/changelog-release-pr/scripts/enrich.test.cjs
+++ b/changelog-release-pr/scripts/enrich.test.cjs
@@ -28,7 +28,7 @@ test('detects breaking label', async () => {
 test('missing pr degrades gracefully (fetcher returns null)', async () => {
   const f = async () => null
   const e = await enrichFromPr('r', 1, f)
-  assert.deepEqual(e, { areas: [], breaking: false, commit: null, author: null })
+  assert.deepEqual(e, { areas: [], breaking: false, commit: null, author: null, languages: null })
 })
 
 test('no merge sha yields null commit', async () => {
@@ -36,4 +36,28 @@ test('no merge sha yields null commit', async () => {
   const e = await enrichFromPr('r', 1, f)
   assert.equal(e.commit, null)
   assert.equal(e.author, null)
+})
+
+test('derives languages from monorepo top-level dirs', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x', files: ['strands-py/src/agent.py', 'strands-py/tests/t.py'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.deepEqual(e.languages, ['python'])
+})
+
+test('PR touching both sdk dirs yields both languages', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x', files: ['strands-py/a.py', 'strands-ts/b.ts'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.deepEqual(e.languages.sort(), ['python', 'typescript'])
+})
+
+test('site/ci/docs-only PR yields empty languages', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x', files: ['site/src/page.astro', '.github/workflows/x.yml', 'designs/d.md'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.deepEqual(e.languages, [])
+})
+
+test('missing files info yields null languages (unknown — keep everywhere)', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x' })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.languages, null)
 })

--- a/changelog-release-pr/scripts/enrich.test.cjs
+++ b/changelog-release-pr/scripts/enrich.test.cjs
@@ -28,7 +28,26 @@ test('detects breaking label', async () => {
 test('missing pr degrades gracefully (fetcher returns null)', async () => {
   const f = async () => null
   const e = await enrichFromPr('r', 1, f)
-  assert.deepEqual(e, { areas: [], breaking: false, commit: null, author: null, languages: null })
+  assert.deepEqual(e, { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false })
+})
+
+test('docsOnly true when every file is under site/ or docs/', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x', files: ['site/src/content/blog/post.md', 'docs/guide.md'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.docsOnly, true)
+})
+
+test('docsOnly false when a PR also touches code', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x', files: ['site/blog/post.md', 'strands-py/src/agent.py'] })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.docsOnly, false)
+})
+
+test('docsOnly false on unknown or empty file info (do not drop)', async () => {
+  const unknown = await enrichFromPr('r', 1, async () => ({ labels: [], merge_commit_sha: 'a', user: 'x' }))
+  assert.equal(unknown.docsOnly, false)
+  const empty = await enrichFromPr('r', 1, async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: [] }))
+  assert.equal(empty.docsOnly, false)
 })
 
 test('no merge sha yields null commit', async () => {

--- a/changelog-release-pr/scripts/enrich.test.cjs
+++ b/changelog-release-pr/scripts/enrich.test.cjs
@@ -1,0 +1,39 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { enrichFromPr } = require('./enrich.cjs')
+
+test('extracts areas, commit, author', async () => {
+  const fetcher = async (repo, num) => {
+    assert.equal(repo, 'strands-agents/harness-sdk')
+    assert.equal(num, 2287)
+    return {
+      labels: ['enhancement', 'python', 'area-model', 'area-otel', 'size/xs'],
+      merge_commit_sha: '155239dca769c8eea7652b2496822ea47283a1a9',
+      user: 'yatszhash',
+    }
+  }
+  const e = await enrichFromPr('strands-agents/harness-sdk', 2287, fetcher)
+  assert.deepEqual(e.areas, ['model', 'otel'])
+  assert.equal(e.breaking, false)
+  assert.equal(e.commit, '155239d')
+  assert.equal(e.author, 'yatszhash')
+})
+
+test('detects breaking label', async () => {
+  const f = async () => ({ labels: ['breaking change'], merge_commit_sha: 'abcdef0123', user: 'x' })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.breaking, true)
+})
+
+test('missing pr degrades gracefully (fetcher returns null)', async () => {
+  const f = async () => null
+  const e = await enrichFromPr('r', 1, f)
+  assert.deepEqual(e, { areas: [], breaking: false, commit: null, author: null })
+})
+
+test('no merge sha yields null commit', async () => {
+  const f = async () => ({ labels: [], merge_commit_sha: null, user: null })
+  const e = await enrichFromPr('r', 1, f)
+  assert.equal(e.commit, null)
+  assert.equal(e.author, null)
+})

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -1,0 +1,63 @@
+// Parse GitHub's auto-generated "What's Changed" release body into structured
+// lines. Pure, dependency-free.
+//
+// Line shape: "* <type>(<scope>)!: <title> by @<author> in <pr-url>"
+// (scope, '!' marker, and "by @author" are all optional).
+
+const LINE = /^\s*[-*]\s+(.*)$/
+// "<msg> by @<author> in <pr-url>"  OR  "<msg> in <pr-url>"
+const TAIL = /^(.*?)(?:\s+by\s+@([\w-]+))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
+const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
+const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
+
+/**
+ * @param {string|null|undefined} body
+ * @returns {Array<{type:string,scope:string|null,breaking:boolean,title:string,author:string|null,pr:number|null,prRepo:string|null}>}
+ */
+function parseReleaseBody(body) {
+  if (!body) return []
+  const out = []
+  for (const raw of body.split('\n')) {
+    const li = raw.match(LINE)
+    if (!li) continue
+    const tail = li[1].trim().match(TAIL)
+    if (!tail) continue // not an itemized PR line (skips "omitted" notes, footers)
+    const message = tail[1].trim()
+    const author = tail[2] || null
+    const prRepo = tail[3] || null
+    const pr = tail[4] ? Number(tail[4]) : null
+
+    const cc = message.match(CONVENTIONAL)
+    if (cc) {
+      const type = cc[1].toLowerCase()
+      out.push({
+        type: KNOWN_TYPES.has(type) ? type : 'other',
+        scope: cc[2] || null,
+        breaking: cc[3] === '!',
+        title: cc[4].trim(),
+        author, pr, prRepo,
+      })
+    } else {
+      out.push({ type: 'other', scope: null, breaking: false, title: message, author, pr, prRepo })
+    }
+  }
+  return out
+}
+
+// Loosely count bullets that look like changelog entries, using a format-
+// INDEPENDENT heuristic (a list bullet mentioning an author '@' or a PR
+// '#'/'/pull/'). Deliberately looser than parseReleaseBody's strict TAIL: if
+// this is high but parseReleaseBody returns far fewer, the release-note format
+// has likely drifted (or notes are hand-written) and callers should flag it.
+const LOOSE_ENTRY = /(@[\w-]+|#\d+|\/pull\/\d+)/
+function countChangelogBullets(body) {
+  if (!body) return 0
+  let n = 0
+  for (const raw of body.split('\n')) {
+    const li = raw.match(LINE)
+    if (li && LOOSE_ENTRY.test(li[1])) n++
+  }
+  return n
+}
+
+module.exports = { parseReleaseBody, countChangelogBullets }

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -5,9 +5,17 @@
 // (scope, '!' marker, and "by @author" are all optional).
 
 const LINE = /^\s*[-*]\s+(.*)$/
-// "<msg> by @<author> in <pr-url>"  OR  "<msg> in <pr-url>"
+// "<msg> by @<author> in <ref>", where <ref> is either a full PR URL (older
+// auto-generated notes) or a short "#<n>" (newer curated notes). "by @author"
+// is optional. For the short form there's no repo in the ref, so prRepo is
+// null and the caller defaults it to the release's own repo.
 // Author logins may carry a bracket suffix for apps/bots, e.g. dependabot[bot].
-const TAIL = /^(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
+const TAIL =
+  /^(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+(?:https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)|#(\d+))\s*$/i
+// Cross-SDK marker in newer harness notes, e.g. "title _(shared with TS)_".
+// Language gating (from PR changed files) already decides stream membership,
+// so strip this annotation from the rendered title.
+const SHARED_ANNOTATION = /\s*_\(shared with [^)]+\)_\s*$/i
 const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
 const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
 // GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".
@@ -29,10 +37,12 @@ function parseReleaseBody(body) {
     if (FIRST_CONTRIBUTION.test(li[1].trim())) continue // celebrated separately
     const tail = li[1].trim().match(TAIL)
     if (!tail) continue // not an itemized PR line (skips "omitted" notes, footers)
-    const message = tail[1].trim()
+    const message = tail[1].trim().replace(SHARED_ANNOTATION, '')
     const author = tail[2] || null
+    // Full-URL form fills groups 3 (repo) + 4 (pr); short "#n" form fills group 5
+    // with no repo, so prRepo stays null and the caller uses the release repo.
     const prRepo = tail[3] || null
-    const pr = tail[4] ? Number(tail[4]) : null
+    const pr = tail[4] ? Number(tail[4]) : tail[5] ? Number(tail[5]) : null
 
     const cc = message.match(CONVENTIONAL)
     if (cc) {

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -1,17 +1,11 @@
-// Parse GitHub's auto-generated "What's Changed" release body into structured
-// lines. Pure, dependency-free.
+// Parse the "New Contributors" section of a GitHub release body, and classify
+// PR titles into changelog fields. Pure, dependency-free.
 //
-// Line shape: "* <type>(<scope>)!: <title> by @<author> in <pr-url>"
-// (scope, '!' marker, and "by @author" are all optional).
+// Entries themselves are derived from the compare API (see derive-entries.cjs),
+// not parsed from the body — so the body is read only for the "New Contributors"
+// section, which the compare API doesn't expose.
 
 const LINE = /^\s*[-*]\s+(.*)$/
-// "<msg> by @<author> in <ref>", where <ref> is either a full PR URL (older
-// auto-generated notes) or a short "#<n>" (newer curated notes). "by @author"
-// is optional. For the short form there's no repo in the ref, so prRepo is
-// null and the caller defaults it to the release's own repo.
-// Author logins may carry a bracket suffix for apps/bots, e.g. dependabot[bot].
-const TAIL =
-  /^(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+(?:https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)|#(\d+))\s*$/i
 // Cross-SDK marker in newer harness notes, e.g. "title _(shared with TS)_".
 // Language gating (from PR changed files) already decides stream membership,
 // so strip this annotation from the rendered title.
@@ -19,15 +13,14 @@ const SHARED_ANNOTATION = /\s*_\(shared with [^)]+\)_\s*$/i
 const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
 const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
 // GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".
-// These are celebrated separately (parseNewContributors) and must NOT become entries.
-// Login pattern must mirror TAIL's (incl. the bracket suffix for bots like dependabot[bot]).
+// Login may carry a bracket suffix for apps/bots, e.g. dependabot[bot].
 const FIRST_CONTRIBUTION = /^@([\w-]+(?:\[[\w-]+\])?) made their first contribution\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
 
 /**
  * Classify a PR title / commit message into changelog fields. Strips the
  * cross-SDK "_(shared with …)_" annotation, then applies the conventional-commit
  * grammar (type/scope/!), falling back to type "other" for non-conventional
- * titles. Shared by parseReleaseBody and the compare-driven derive-entries path.
+ * titles. Used by the compare-driven derive-entries path.
  * @param {string} message
  * @returns {{type:string, scope:string|null, breaking:boolean, title:string}}
  */
@@ -39,46 +32,6 @@ function classifyTitle(message) {
     return { type: KNOWN_TYPES.has(type) ? type : 'other', scope: cc[2] || null, breaking: cc[3] === '!', title: cc[4].trim() }
   }
   return { type: 'other', scope: null, breaking: false, title: msg }
-}
-
-/**
- * @param {string|null|undefined} body
- * @returns {Array<{type:string,scope:string|null,breaking:boolean,title:string,author:string|null,pr:number|null,prRepo:string|null}>}
- */
-function parseReleaseBody(body) {
-  if (!body) return []
-  const out = []
-  // GitHub release bodies use CRLF; normalize so trailing \r doesn't break matches.
-  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
-    const li = raw.match(LINE)
-    if (!li) continue
-    if (FIRST_CONTRIBUTION.test(li[1].trim())) continue // celebrated separately
-    const tail = li[1].trim().match(TAIL)
-    if (!tail) continue // not an itemized PR line (skips "omitted" notes, footers)
-    const author = tail[2] || null
-    // Full-URL form fills groups 3 (repo) + 4 (pr); short "#n" form fills group 5
-    // with no repo, so prRepo stays null and the caller uses the release repo.
-    const prRepo = tail[3] || null
-    const pr = tail[4] ? Number(tail[4]) : tail[5] ? Number(tail[5]) : null
-    out.push({ ...classifyTitle(tail[1]), author, pr, prRepo })
-  }
-  return out
-}
-
-// Loosely count bullets that look like changelog entries, using a format-
-// INDEPENDENT heuristic (a list bullet mentioning an author '@' or a PR
-// '#'/'/pull/'). Deliberately looser than parseReleaseBody's strict TAIL: if
-// this is high but parseReleaseBody returns far fewer, the release-note format
-// has likely drifted (or notes are hand-written) and callers should flag it.
-const LOOSE_ENTRY = /(@[\w-]+|#\d+|\/pull\/\d+)/
-function countChangelogBullets(body) {
-  if (!body) return 0
-  let n = 0
-  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
-    const li = raw.match(LINE)
-    if (li && LOOSE_ENTRY.test(li[1]) && !FIRST_CONTRIBUTION.test(li[1].trim())) n++
-  }
-  return n
 }
 
 /**
@@ -100,4 +53,4 @@ function parseNewContributors(body) {
   return out
 }
 
-module.exports = { parseReleaseBody, classifyTitle, countChangelogBullets, parseNewContributors }
+module.exports = { classifyTitle, parseNewContributors }

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -9,6 +9,9 @@ const LINE = /^\s*[-*]\s+(.*)$/
 const TAIL = /^(.*?)(?:\s+by\s+@([\w-]+))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
 const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
 const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
+// GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".
+// These are celebrated separately (parseNewContributors) and must NOT become entries.
+const FIRST_CONTRIBUTION = /^@([\w-]+) made their first contribution\s+in\s+https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)\s*$/i
 
 /**
  * @param {string|null|undefined} body
@@ -21,6 +24,7 @@ function parseReleaseBody(body) {
   for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
     const li = raw.match(LINE)
     if (!li) continue
+    if (FIRST_CONTRIBUTION.test(li[1].trim())) continue // celebrated separately
     const tail = li[1].trim().match(TAIL)
     if (!tail) continue // not an itemized PR line (skips "omitted" notes, footers)
     const message = tail[1].trim()
@@ -56,9 +60,26 @@ function countChangelogBullets(body) {
   let n = 0
   for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
     const li = raw.match(LINE)
-    if (li && LOOSE_ENTRY.test(li[1])) n++
+    if (li && LOOSE_ENTRY.test(li[1]) && !FIRST_CONTRIBUTION.test(li[1].trim())) n++
   }
   return n
 }
 
-module.exports = { parseReleaseBody, countChangelogBullets }
+/**
+ * Extract GitHub's "## New Contributors" section into structured data.
+ * @param {string|null|undefined} body
+ * @returns {Array<{login:string, pr:number}>}
+ */
+function parseNewContributors(body) {
+  if (!body) return []
+  const out = []
+  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
+    const li = raw.match(LINE)
+    if (!li) continue
+    const m = li[1].trim().match(FIRST_CONTRIBUTION)
+    if (m) out.push({ login: m[1], pr: Number(m[2]) })
+  }
+  return out
+}
+
+module.exports = { parseReleaseBody, countChangelogBullets, parseNewContributors }

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -12,7 +12,8 @@ const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|re
 const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
 // GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".
 // These are celebrated separately (parseNewContributors) and must NOT become entries.
-const FIRST_CONTRIBUTION = /^@([\w-]+) made their first contribution\s+in\s+https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)\s*$/i
+// Login pattern must mirror TAIL's (incl. the bracket suffix for bots like dependabot[bot]).
+const FIRST_CONTRIBUTION = /^@([\w-]+(?:\[[\w-]+\])?) made their first contribution\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
 
 /**
  * @param {string|null|undefined} body
@@ -68,8 +69,10 @@ function countChangelogBullets(body) {
 
 /**
  * Extract GitHub's "## New Contributors" section into structured data.
+ * prRepo is the repo from the PR url (may differ from the release's repo for
+ * pre-monorepo releases) — gate/enrich against THAT repo, mirroring entries.
  * @param {string|null|undefined} body
- * @returns {Array<{login:string, pr:number}>}
+ * @returns {Array<{login:string, pr:number, prRepo:string}>}
  */
 function parseNewContributors(body) {
   if (!body) return []
@@ -78,7 +81,7 @@ function parseNewContributors(body) {
     const li = raw.match(LINE)
     if (!li) continue
     const m = li[1].trim().match(FIRST_CONTRIBUTION)
-    if (m) out.push({ login: m[1], pr: Number(m[2]) })
+    if (m) out.push({ login: m[1], pr: Number(m[3]), prRepo: m[2] })
   }
   return out
 }

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -17,7 +17,8 @@ const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 
 function parseReleaseBody(body) {
   if (!body) return []
   const out = []
-  for (const raw of body.split('\n')) {
+  // GitHub release bodies use CRLF; normalize so trailing \r doesn't break matches.
+  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
     const li = raw.match(LINE)
     if (!li) continue
     const tail = li[1].trim().match(TAIL)
@@ -53,7 +54,7 @@ const LOOSE_ENTRY = /(@[\w-]+|#\d+|\/pull\/\d+)/
 function countChangelogBullets(body) {
   if (!body) return 0
   let n = 0
-  for (const raw of body.split('\n')) {
+  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
     const li = raw.match(LINE)
     if (li && LOOSE_ENTRY.test(li[1])) n++
   }

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -6,7 +6,8 @@
 
 const LINE = /^\s*[-*]\s+(.*)$/
 // "<msg> by @<author> in <pr-url>"  OR  "<msg> in <pr-url>"
-const TAIL = /^(.*?)(?:\s+by\s+@([\w-]+))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
+// Author logins may carry a bracket suffix for apps/bots, e.g. dependabot[bot].
+const TAIL = /^(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
 const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
 const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
 // GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".

--- a/changelog-release-pr/scripts/parse-release-body.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.cjs
@@ -24,6 +24,24 @@ const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 
 const FIRST_CONTRIBUTION = /^@([\w-]+(?:\[[\w-]+\])?) made their first contribution\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
 
 /**
+ * Classify a PR title / commit message into changelog fields. Strips the
+ * cross-SDK "_(shared with …)_" annotation, then applies the conventional-commit
+ * grammar (type/scope/!), falling back to type "other" for non-conventional
+ * titles. Shared by parseReleaseBody and the compare-driven derive-entries path.
+ * @param {string} message
+ * @returns {{type:string, scope:string|null, breaking:boolean, title:string}}
+ */
+function classifyTitle(message) {
+  const msg = String(message).trim().replace(SHARED_ANNOTATION, '')
+  const cc = msg.match(CONVENTIONAL)
+  if (cc) {
+    const type = cc[1].toLowerCase()
+    return { type: KNOWN_TYPES.has(type) ? type : 'other', scope: cc[2] || null, breaking: cc[3] === '!', title: cc[4].trim() }
+  }
+  return { type: 'other', scope: null, breaking: false, title: msg }
+}
+
+/**
  * @param {string|null|undefined} body
  * @returns {Array<{type:string,scope:string|null,breaking:boolean,title:string,author:string|null,pr:number|null,prRepo:string|null}>}
  */
@@ -37,26 +55,12 @@ function parseReleaseBody(body) {
     if (FIRST_CONTRIBUTION.test(li[1].trim())) continue // celebrated separately
     const tail = li[1].trim().match(TAIL)
     if (!tail) continue // not an itemized PR line (skips "omitted" notes, footers)
-    const message = tail[1].trim().replace(SHARED_ANNOTATION, '')
     const author = tail[2] || null
     // Full-URL form fills groups 3 (repo) + 4 (pr); short "#n" form fills group 5
     // with no repo, so prRepo stays null and the caller uses the release repo.
     const prRepo = tail[3] || null
     const pr = tail[4] ? Number(tail[4]) : tail[5] ? Number(tail[5]) : null
-
-    const cc = message.match(CONVENTIONAL)
-    if (cc) {
-      const type = cc[1].toLowerCase()
-      out.push({
-        type: KNOWN_TYPES.has(type) ? type : 'other',
-        scope: cc[2] || null,
-        breaking: cc[3] === '!',
-        title: cc[4].trim(),
-        author, pr, prRepo,
-      })
-    } else {
-      out.push({ type: 'other', scope: null, breaking: false, title: message, author, pr, prRepo })
-    }
+    out.push({ ...classifyTitle(tail[1]), author, pr, prRepo })
   }
   return out
 }
@@ -96,4 +100,4 @@ function parseNewContributors(body) {
   return out
 }
 
-module.exports = { parseReleaseBody, countChangelogBullets, parseNewContributors }
+module.exports = { parseReleaseBody, classifyTitle, countChangelogBullets, parseNewContributors }

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -1,6 +1,6 @@
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
-const { parseReleaseBody, countChangelogBullets } = require('./parse-release-body.cjs')
+const { parseReleaseBody, countChangelogBullets, parseNewContributors } = require('./parse-release-body.cjs')
 
 const body = `## What's Changed
 
@@ -60,6 +60,34 @@ test('handles CRLF line endings (real GitHub bodies)', () => {
   assert.equal(lines[0].scope, 'model')
   assert.equal(lines[0].title, 'x') // no trailing \r
   assert.equal(countChangelogBullets(crlf), 2)
+})
+
+const nc = `## What's Changed
+* feat: real change by @dev in https://github.com/o/r/pull/1
+
+## New Contributors
+* @senthilkumarmohan made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2623
+* @ianholtz made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2651
+
+**Full Changelog**: https://github.com/o/r/compare/a...b`
+
+test('parseNewContributors extracts structured logins + prs', () => {
+  assert.deepEqual(parseNewContributors(nc), [
+    { login: 'senthilkumarmohan', pr: 2623 },
+    { login: 'ianholtz', pr: 2651 },
+  ])
+  assert.deepEqual(parseNewContributors(''), [])
+  assert.deepEqual(parseNewContributors(null), [])
+})
+
+test('first-contribution lines are excluded from entries', () => {
+  const lines = parseReleaseBody(nc)
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].title, 'real change')
+})
+
+test('countChangelogBullets ignores first-contribution lines (no false drift)', () => {
+  assert.equal(countChangelogBullets(nc), 1)
 })
 
 test('countChangelogBullets stays loose vs strict parser (drift signal)', () => {

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -53,6 +53,15 @@ test('countChangelogBullets counts entry-like bullets, ignores notes', () => {
   assert.equal(countChangelogBullets(''), 0)
 })
 
+test('handles CRLF line endings (real GitHub bodies)', () => {
+  const crlf = "## What's Changed\r\n\r\n* feat(model): x by @a in https://github.com/o/r/pull/1\r\n* fix: y by @b in https://github.com/o/r/pull/2\r\n"
+  const lines = parseReleaseBody(crlf)
+  assert.equal(lines.length, 2)
+  assert.equal(lines[0].scope, 'model')
+  assert.equal(lines[0].title, 'x') // no trailing \r
+  assert.equal(countChangelogBullets(crlf), 2)
+})
+
 test('countChangelogBullets stays loose vs strict parser (drift signal)', () => {
   // PR refs as #123 instead of full URL: loose counter sees them, strict parser does not.
   const drifted = '* updated thing #11\n* fixed thing #12\n* added thing #13'

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -13,19 +13,15 @@ const body = `## What's Changed
 **Full Changelog**: https://github.com/strands-agents/sdk-python/compare/python/v1.41.0...python/v1.42.0`
 
 test('parses conventional-commit lines', () => {
-  const lines = parseReleaseBody(body)
-  assert.equal(lines.length, 5)
-  assert.deepEqual(lines[0], {
-    type: 'fix', scope: 'tests', breaking: false,
-    title: 'fix flaky tests', author: 'lizradway',
-    pr: 2319, prRepo: 'strands-agents/sdk-python',
-  })
-  assert.equal(lines[1].type, 'feat')
-  assert.equal(lines[1].scope, 'gemini')
-  assert.equal(lines[2].breaking, true) // '!' marker
-  assert.equal(lines[2].type, 'feat')
-  assert.equal(lines[4].author, null) // line without "by @author"
-  assert.equal(lines[4].pr, 2301)
+  // Whole-shape equality: the parser is deterministic, so assert everything.
+  const repo = 'strands-agents/sdk-python'
+  assert.deepEqual(parseReleaseBody(body), [
+    { type: 'fix', scope: 'tests', breaking: false, title: 'fix flaky tests', author: 'lizradway', pr: 2319, prRepo: repo },
+    { type: 'feat', scope: 'gemini', breaking: false, title: 'plumb through cache tokens', author: 'yatszhash', pr: 2287, prRepo: repo },
+    { type: 'feat', scope: null, breaking: true, title: 'drop legacy run()', author: 'pgrayy', pr: 2299, prRepo: repo },
+    { type: 'docs', scope: null, breaking: false, title: 'tidy readme', author: 'someone', pr: 2300, prRepo: repo },
+    { type: 'chore', scope: null, breaking: false, title: 'bump deps', author: null, pr: 2301, prRepo: repo },
+  ])
 })
 
 test('omitted-list body yields no entries', () => {
@@ -81,13 +77,19 @@ const nc = `## What's Changed
 
 **Full Changelog**: https://github.com/o/r/compare/a...b`
 
-test('parseNewContributors extracts structured logins + prs', () => {
+test('parseNewContributors extracts structured logins + prs + prRepo', () => {
   assert.deepEqual(parseNewContributors(nc), [
-    { login: 'senthilkumarmohan', pr: 2623 },
-    { login: 'ianholtz', pr: 2651 },
+    { login: 'senthilkumarmohan', pr: 2623, prRepo: 'strands-agents/harness-sdk' },
+    { login: 'ianholtz', pr: 2651, prRepo: 'strands-agents/harness-sdk' },
   ])
   assert.deepEqual(parseNewContributors(''), [])
   assert.deepEqual(parseNewContributors(null), [])
+})
+
+test('bracket-suffixed bot first-contribution lines are captured, not leaked into entries', () => {
+  const body = '* @dependabot[bot] made their first contribution in https://github.com/o/r/pull/625'
+  assert.deepEqual(parseNewContributors(body), [{ login: 'dependabot[bot]', pr: 625, prRepo: 'o/r' }])
+  assert.deepEqual(parseReleaseBody(body), []) // must NOT become an entry
 })
 
 test('first-contribution lines are excluded from entries', () => {

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -1,0 +1,61 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { parseReleaseBody, countChangelogBullets } = require('./parse-release-body.cjs')
+
+const body = `## What's Changed
+
+* fix(tests): fix flaky tests by @lizradway in https://github.com/strands-agents/sdk-python/pull/2319
+* feat(gemini): plumb through cache tokens by @yatszhash in https://github.com/strands-agents/sdk-python/pull/2287
+* feat!: drop legacy run() by @pgrayy in https://github.com/strands-agents/sdk-python/pull/2299
+* docs: tidy readme by @someone in https://github.com/strands-agents/sdk-python/pull/2300
+* chore: bump deps in https://github.com/strands-agents/sdk-python/pull/2301
+
+**Full Changelog**: https://github.com/strands-agents/sdk-python/compare/python/v1.41.0...python/v1.42.0`
+
+test('parses conventional-commit lines', () => {
+  const lines = parseReleaseBody(body)
+  assert.equal(lines.length, 5)
+  assert.deepEqual(lines[0], {
+    type: 'fix', scope: 'tests', breaking: false,
+    title: 'fix flaky tests', author: 'lizradway',
+    pr: 2319, prRepo: 'strands-agents/sdk-python',
+  })
+  assert.equal(lines[1].type, 'feat')
+  assert.equal(lines[1].scope, 'gemini')
+  assert.equal(lines[2].breaking, true) // '!' marker
+  assert.equal(lines[2].type, 'feat')
+  assert.equal(lines[4].author, null) // line without "by @author"
+  assert.equal(lines[4].pr, 2301)
+})
+
+test('omitted-list body yields no entries', () => {
+  assert.deepEqual(
+    parseReleaseBody("## What's Changed\n\n*auto-generated itemized list omitted due to mono-repository merge*"),
+    []
+  )
+})
+
+test('empty/undefined body yields no entries', () => {
+  assert.deepEqual(parseReleaseBody(''), [])
+  assert.deepEqual(parseReleaseBody(null), [])
+})
+
+test('non-conventional line falls back to type other', () => {
+  const lines = parseReleaseBody('* just did a thing by @x in https://github.com/o/r/pull/9')
+  assert.equal(lines[0].type, 'other')
+  assert.equal(lines[0].scope, null)
+  assert.equal(lines[0].title, 'just did a thing')
+})
+
+test('countChangelogBullets counts entry-like bullets, ignores notes', () => {
+  assert.equal(countChangelogBullets(body), 5)
+  assert.equal(countChangelogBullets('* auto-generated itemized list omitted'), 0)
+  assert.equal(countChangelogBullets(''), 0)
+})
+
+test('countChangelogBullets stays loose vs strict parser (drift signal)', () => {
+  // PR refs as #123 instead of full URL: loose counter sees them, strict parser does not.
+  const drifted = '* updated thing #11\n* fixed thing #12\n* added thing #13'
+  assert.equal(countChangelogBullets(drifted), 3)
+  assert.equal(parseReleaseBody(drifted).length, 0)
+})

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -46,6 +46,28 @@ test('bot authors with bracket suffix parse cleanly (no title pollution)', () =>
   assert.equal(lines[0].pr, 625)
 })
 
+test('parses short "in #N" pr refs (newer curated note format)', () => {
+  // Newer harness notes use "by @author in #2740" (no full URL) plus emoji
+  // section headers. prRepo is null so the caller defaults it to the release repo.
+  const lines = parseReleaseBody(
+    [
+      '### ✨ Features',
+      '* feat(memory): port memory manager by @JackYPCOnline in #2740',
+      '* feat: pass invocation_state to edge condition calls by @yananym in #2642',
+    ].join('\n')
+  )
+  assert.equal(lines.length, 2)
+  assert.deepEqual(lines[0], { type: 'feat', scope: 'memory', breaking: false, title: 'port memory manager', author: 'JackYPCOnline', pr: 2740, prRepo: null })
+  assert.equal(lines[1].pr, 2642)
+})
+
+test('strips "_(shared with TS/Python)_" cross-SDK annotation from titles', () => {
+  const lines = parseReleaseBody('* feat: add memory injection _(shared with TS)_ by @opieter-aws in #2797')
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].title, 'add memory injection')
+  assert.equal(lines[0].pr, 2797)
+})
+
 test('non-conventional line falls back to type other', () => {
   const lines = parseReleaseBody('* just did a thing by @x in https://github.com/o/r/pull/9')
   assert.equal(lines[0].type, 'other')

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -1,94 +1,38 @@
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
-const { parseReleaseBody, countChangelogBullets, parseNewContributors } = require('./parse-release-body.cjs')
+const { classifyTitle, parseNewContributors } = require('./parse-release-body.cjs')
 
-const body = `## What's Changed
+// --- classifyTitle -----------------------------------------------------------
 
-* fix(tests): fix flaky tests by @lizradway in https://github.com/strands-agents/sdk-python/pull/2319
-* feat(gemini): plumb through cache tokens by @yatszhash in https://github.com/strands-agents/sdk-python/pull/2287
-* feat!: drop legacy run() by @pgrayy in https://github.com/strands-agents/sdk-python/pull/2299
-* docs: tidy readme by @someone in https://github.com/strands-agents/sdk-python/pull/2300
-* chore: bump deps in https://github.com/strands-agents/sdk-python/pull/2301
-
-**Full Changelog**: https://github.com/strands-agents/sdk-python/compare/python/v1.41.0...python/v1.42.0`
-
-test('parses conventional-commit lines', () => {
-  // Whole-shape equality: the parser is deterministic, so assert everything.
-  const repo = 'strands-agents/sdk-python'
-  assert.deepEqual(parseReleaseBody(body), [
-    { type: 'fix', scope: 'tests', breaking: false, title: 'fix flaky tests', author: 'lizradway', pr: 2319, prRepo: repo },
-    { type: 'feat', scope: 'gemini', breaking: false, title: 'plumb through cache tokens', author: 'yatszhash', pr: 2287, prRepo: repo },
-    { type: 'feat', scope: null, breaking: true, title: 'drop legacy run()', author: 'pgrayy', pr: 2299, prRepo: repo },
-    { type: 'docs', scope: null, breaking: false, title: 'tidy readme', author: 'someone', pr: 2300, prRepo: repo },
-    { type: 'chore', scope: null, breaking: false, title: 'bump deps', author: null, pr: 2301, prRepo: repo },
-  ])
+test('classifies conventional-commit titles (type/scope/breaking)', () => {
+  assert.deepEqual(classifyTitle('fix(tests): fix flaky tests'), {
+    type: 'fix', scope: 'tests', breaking: false, title: 'fix flaky tests',
+  })
+  assert.deepEqual(classifyTitle('feat(gemini): plumb through cache tokens'), {
+    type: 'feat', scope: 'gemini', breaking: false, title: 'plumb through cache tokens',
+  })
+  assert.deepEqual(classifyTitle('feat!: drop legacy run()'), {
+    type: 'feat', scope: null, breaking: true, title: 'drop legacy run()',
+  })
 })
 
-test('omitted-list body yields no entries', () => {
-  assert.deepEqual(
-    parseReleaseBody("## What's Changed\n\n*auto-generated itemized list omitted due to mono-repository merge*"),
-    []
-  )
+test('maps non-changelog conventional types (build/ci/style/revert) to other', () => {
+  // KNOWN_TYPES is the changelog-visible subset; everything else collapses to 'other'.
+  assert.equal(classifyTitle('ci: bump runner').type, 'other')
+  assert.equal(classifyTitle('build(deps): bump uuid').type, 'other')
 })
 
-test('empty/undefined body yields no entries', () => {
-  assert.deepEqual(parseReleaseBody(''), [])
-  assert.deepEqual(parseReleaseBody(null), [])
+test('non-conventional title falls back to type other', () => {
+  assert.deepEqual(classifyTitle('just did a thing'), {
+    type: 'other', scope: null, breaking: false, title: 'just did a thing',
+  })
 })
 
-test('bot authors with bracket suffix parse cleanly (no title pollution)', () => {
-  const lines = parseReleaseBody(
-    '* chore(deps): bump uuid from 10.0.0 to 13.0.0 by @dependabot[bot] in https://github.com/o/r/pull/625'
-  )
-  assert.equal(lines.length, 1)
-  assert.equal(lines[0].title, 'bump uuid from 10.0.0 to 13.0.0')
-  assert.equal(lines[0].author, 'dependabot[bot]')
-  assert.equal(lines[0].pr, 625)
+test('strips the "_(shared with TS/Python)_" cross-SDK annotation from the title', () => {
+  assert.equal(classifyTitle('feat: add memory injection _(shared with TS)_').title, 'add memory injection')
 })
 
-test('parses short "in #N" pr refs (newer curated note format)', () => {
-  // Newer harness notes use "by @author in #2740" (no full URL) plus emoji
-  // section headers. prRepo is null so the caller defaults it to the release repo.
-  const lines = parseReleaseBody(
-    [
-      '### ✨ Features',
-      '* feat(memory): port memory manager by @JackYPCOnline in #2740',
-      '* feat: pass invocation_state to edge condition calls by @yananym in #2642',
-    ].join('\n')
-  )
-  assert.equal(lines.length, 2)
-  assert.deepEqual(lines[0], { type: 'feat', scope: 'memory', breaking: false, title: 'port memory manager', author: 'JackYPCOnline', pr: 2740, prRepo: null })
-  assert.equal(lines[1].pr, 2642)
-})
-
-test('strips "_(shared with TS/Python)_" cross-SDK annotation from titles', () => {
-  const lines = parseReleaseBody('* feat: add memory injection _(shared with TS)_ by @opieter-aws in #2797')
-  assert.equal(lines.length, 1)
-  assert.equal(lines[0].title, 'add memory injection')
-  assert.equal(lines[0].pr, 2797)
-})
-
-test('non-conventional line falls back to type other', () => {
-  const lines = parseReleaseBody('* just did a thing by @x in https://github.com/o/r/pull/9')
-  assert.equal(lines[0].type, 'other')
-  assert.equal(lines[0].scope, null)
-  assert.equal(lines[0].title, 'just did a thing')
-})
-
-test('countChangelogBullets counts entry-like bullets, ignores notes', () => {
-  assert.equal(countChangelogBullets(body), 5)
-  assert.equal(countChangelogBullets('* auto-generated itemized list omitted'), 0)
-  assert.equal(countChangelogBullets(''), 0)
-})
-
-test('handles CRLF line endings (real GitHub bodies)', () => {
-  const crlf = "## What's Changed\r\n\r\n* feat(model): x by @a in https://github.com/o/r/pull/1\r\n* fix: y by @b in https://github.com/o/r/pull/2\r\n"
-  const lines = parseReleaseBody(crlf)
-  assert.equal(lines.length, 2)
-  assert.equal(lines[0].scope, 'model')
-  assert.equal(lines[0].title, 'x') // no trailing \r
-  assert.equal(countChangelogBullets(crlf), 2)
-})
+// --- parseNewContributors ----------------------------------------------------
 
 const nc = `## What's Changed
 * feat: real change by @dev in https://github.com/o/r/pull/1
@@ -99,34 +43,30 @@ const nc = `## What's Changed
 
 **Full Changelog**: https://github.com/o/r/compare/a...b`
 
-test('parseNewContributors extracts structured logins + prs + prRepo', () => {
+test('extracts structured logins + prs + prRepo', () => {
   assert.deepEqual(parseNewContributors(nc), [
     { login: 'senthilkumarmohan', pr: 2623, prRepo: 'strands-agents/harness-sdk' },
     { login: 'ianholtz', pr: 2651, prRepo: 'strands-agents/harness-sdk' },
   ])
+})
+
+test('empty/undefined body yields no contributors', () => {
   assert.deepEqual(parseNewContributors(''), [])
   assert.deepEqual(parseNewContributors(null), [])
 })
 
-test('bracket-suffixed bot first-contribution lines are captured, not leaked into entries', () => {
+test('captures bracket-suffixed bot logins (e.g. dependabot[bot])', () => {
   const body = '* @dependabot[bot] made their first contribution in https://github.com/o/r/pull/625'
   assert.deepEqual(parseNewContributors(body), [{ login: 'dependabot[bot]', pr: 625, prRepo: 'o/r' }])
-  assert.deepEqual(parseReleaseBody(body), []) // must NOT become an entry
 })
 
-test('first-contribution lines are excluded from entries', () => {
-  const lines = parseReleaseBody(nc)
-  assert.equal(lines.length, 1)
-  assert.equal(lines[0].title, 'real change')
+test('handles CRLF line endings (real GitHub bodies)', () => {
+  const crlf = '## New Contributors\r\n* @dev made their first contribution in https://github.com/o/r/pull/7\r\n'
+  assert.deepEqual(parseNewContributors(crlf), [{ login: 'dev', pr: 7, prRepo: 'o/r' }])
 })
 
-test('countChangelogBullets ignores first-contribution lines (no false drift)', () => {
-  assert.equal(countChangelogBullets(nc), 1)
-})
-
-test('countChangelogBullets stays loose vs strict parser (drift signal)', () => {
-  // PR refs as #123 instead of full URL: loose counter sees them, strict parser does not.
-  const drifted = '* updated thing #11\n* fixed thing #12\n* added thing #13'
-  assert.equal(countChangelogBullets(drifted), 3)
-  assert.equal(parseReleaseBody(drifted).length, 0)
+test('ignores non-contributor bullets (regular "What\'s Changed" entries)', () => {
+  // Only first-contribution lines are captured; entry bullets are derived from
+  // the compare API, not this parser.
+  assert.deepEqual(parseNewContributors("* feat: real change by @dev in https://github.com/o/r/pull/1"), [])
 })

--- a/changelog-release-pr/scripts/parse-release-body.test.cjs
+++ b/changelog-release-pr/scripts/parse-release-body.test.cjs
@@ -40,6 +40,16 @@ test('empty/undefined body yields no entries', () => {
   assert.deepEqual(parseReleaseBody(null), [])
 })
 
+test('bot authors with bracket suffix parse cleanly (no title pollution)', () => {
+  const lines = parseReleaseBody(
+    '* chore(deps): bump uuid from 10.0.0 to 13.0.0 by @dependabot[bot] in https://github.com/o/r/pull/625'
+  )
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].title, 'bump uuid from 10.0.0 to 13.0.0')
+  assert.equal(lines[0].author, 'dependabot[bot]')
+  assert.equal(lines[0].pr, 625)
+})
+
 test('non-conventional line falls back to type other', () => {
   const lines = parseReleaseBody('* just did a thing by @x in https://github.com/o/r/pull/9')
   assert.equal(lines[0].type, 'other')

--- a/changelog-release-pr/scripts/render-markdown.cjs
+++ b/changelog-release-pr/scripts/render-markdown.cjs
@@ -57,7 +57,6 @@ function renderMarkdown(f, body = '') {
   lines.push(`date: ${f.date}`)
   lines.push(`releaseUrl: ${f.releaseUrl}`)
   lines.push(`packageUrl: ${f.packageUrl}`)
-  if (f.compareUrl) lines.push(`compareUrl: ${f.compareUrl}`)
   if (f.highlights && f.highlights.trim()) {
     lines.push('highlights: |')
     for (const l of f.highlights.replace(/\s+$/, '').split('\n')) lines.push(`  ${l}`)

--- a/changelog-release-pr/scripts/render-markdown.cjs
+++ b/changelog-release-pr/scripts/render-markdown.cjs
@@ -1,0 +1,80 @@
+// Render a release into the changelog markdown file format consumed by the
+// harness-sdk content collection (Plan 1 Zod schema). Hand-rolled minimal YAML
+// emitter — entries are flat objects emitted as inline flow maps, mirroring the
+// committed fixtures. mergePreserving keeps any human-written highlights/body
+// on re-sync while refreshing the parsed entries/urls.
+
+function q(s) {
+  return `"${String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+// Bareword if safe for YAML, else quoted. Anything starting with a digit or
+// containing YAML-significant chars gets quoted.
+function scalar(v) {
+  if (v === null || v === undefined) return 'null'
+  if (typeof v === 'number') return String(v)
+  if (v === '') return '""'
+  if (/^[\w.@/-]+$/.test(v) && !/^\d/.test(v)) return v
+  return q(v)
+}
+
+function flowEntry(e) {
+  const parts = [
+    `type: ${e.type}`,
+    `breaking: ${e.breaking === true}`,
+    `scope: ${e.scope ? scalar(e.scope) : 'null'}`,
+    `areas: [${e.areas.join(', ')}]`,
+    `title: ${q(e.title)}`,
+    `pr: ${e.pr == null ? 'null' : e.pr}`,
+    `prUrl: ${e.prUrl ? q(e.prUrl) : 'null'}`,
+    `commit: ${e.commit ? q(e.commit) : 'null'}`,
+    `commitUrl: ${e.commitUrl ? q(e.commitUrl) : 'null'}`,
+    `author: ${e.author ? scalar(e.author) : 'null'}`,
+  ]
+  return `  - { ${parts.join(', ')} }`
+}
+
+/**
+ * @param {object} f  release file shape (see build-release-file.cjs)
+ * @param {string} [body]  optional curated markdown body to append
+ */
+function renderMarkdown(f, body = '') {
+  const lines = ['---']
+  lines.push(`sdk: ${f.sdk}`)
+  if (f.language) lines.push(`language: ${f.language}`)
+  lines.push(`version: ${q(f.version)}`)
+  lines.push(`tag: ${f.tag}`)
+  lines.push(`date: ${f.date}`)
+  lines.push(`releaseUrl: ${f.releaseUrl}`)
+  lines.push(`packageUrl: ${f.packageUrl}`)
+  if (f.compareUrl) lines.push(`compareUrl: ${f.compareUrl}`)
+  if (f.highlights && f.highlights.trim()) {
+    lines.push('highlights: |')
+    for (const l of f.highlights.replace(/\s+$/, '').split('\n')) lines.push(`  ${l}`)
+  }
+  if (f.entries && f.entries.length) {
+    lines.push('entries:')
+    for (const e of f.entries) lines.push(flowEntry(e))
+  } else {
+    lines.push('entries: []')
+  }
+  lines.push('---')
+  return lines.join('\n') + '\n' + (body ? '\n' + body.replace(/\s+$/, '') + '\n' : '')
+}
+
+// Pull the human-authored highlights block + markdown body out of an existing
+// file so a re-sync doesn't clobber curation. Entries/urls always regenerate.
+function mergePreserving(fresh, existing) {
+  if (!existing) return renderMarkdown(fresh)
+  const fm = existing.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  const body = fm ? fm[2].trim() : ''
+  let highlights = fresh.highlights
+  if (fm) {
+    // Capture a block scalar `highlights: |` up to the next top-level key or EOF.
+    const hl = fm[1].match(/highlights:\s*\|\s*\n([\s\S]*?)(?=\n[A-Za-z][\w-]*:|$)/)
+    if (hl) highlights = hl[1].replace(/^ {1,2}/gm, '').replace(/\s+$/, '')
+  }
+  return renderMarkdown({ ...fresh, highlights }, body)
+}
+
+module.exports = { renderMarkdown, mergePreserving }

--- a/changelog-release-pr/scripts/render-markdown.cjs
+++ b/changelog-release-pr/scripts/render-markdown.cjs
@@ -68,6 +68,12 @@ function renderMarkdown(f, body = '') {
   } else {
     lines.push('entries: []')
   }
+  if (f.newContributors && f.newContributors.length) {
+    lines.push('newContributors:')
+    for (const c of f.newContributors) {
+      lines.push(`  - { login: ${scalar(c.login)}, pr: ${c.pr} }`)
+    }
+  }
   lines.push('---')
   return lines.join('\n') + '\n' + (body ? '\n' + body.replace(/\s+$/, '') + '\n' : '')
 }

--- a/changelog-release-pr/scripts/render-markdown.cjs
+++ b/changelog-release-pr/scripts/render-markdown.cjs
@@ -5,16 +5,26 @@
 // on re-sync while refreshing the parsed entries/urls.
 
 function q(s) {
-  return `"${String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  return `"${String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\t/g, '\\t')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')}"`
 }
 
-// Bareword if safe for YAML, else quoted. Anything starting with a digit or
-// containing YAML-significant chars gets quoted.
+// YAML 1.1 words that, left bare, parse as booleans/null instead of strings.
+const YAML_RESERVED = new Set([
+  'true', 'false', 'yes', 'no', 'on', 'off', 'null', 'none', '~',
+])
+
+// Bareword if safe for YAML, else quoted. Quote anything that starts with a
+// digit, contains YAML-significant chars, or is a reserved bool/null word.
 function scalar(v) {
   if (v === null || v === undefined) return 'null'
   if (typeof v === 'number') return String(v)
   if (v === '') return '""'
-  if (/^[\w.@/-]+$/.test(v) && !/^\d/.test(v)) return v
+  if (/^[\w.@/-]+$/.test(v) && !/^\d/.test(v) && !YAML_RESERVED.has(v.toLowerCase())) return v
   return q(v)
 }
 
@@ -23,7 +33,7 @@ function flowEntry(e) {
     `type: ${e.type}`,
     `breaking: ${e.breaking === true}`,
     `scope: ${e.scope ? scalar(e.scope) : 'null'}`,
-    `areas: [${e.areas.join(', ')}]`,
+    `areas: [${e.areas.map(scalar).join(', ')}]`,
     `title: ${q(e.title)}`,
     `pr: ${e.pr == null ? 'null' : e.pr}`,
     `prUrl: ${e.prUrl ? q(e.prUrl) : 'null'}`,
@@ -43,7 +53,7 @@ function renderMarkdown(f, body = '') {
   lines.push(`sdk: ${f.sdk}`)
   if (f.language) lines.push(`language: ${f.language}`)
   lines.push(`version: ${q(f.version)}`)
-  lines.push(`tag: ${f.tag}`)
+  lines.push(`tag: ${scalar(f.tag)}`)
   lines.push(`date: ${f.date}`)
   lines.push(`releaseUrl: ${f.releaseUrl}`)
   lines.push(`packageUrl: ${f.packageUrl}`)

--- a/changelog-release-pr/scripts/render-markdown.test.cjs
+++ b/changelog-release-pr/scripts/render-markdown.test.cjs
@@ -1,0 +1,89 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { renderMarkdown, mergePreserving } = require('./render-markdown.cjs')
+
+const file = {
+  sdk: 'harness', language: 'python', version: '1.42.0', tag: 'python/v1.42.0',
+  date: '2026-06-01',
+  releaseUrl: 'https://github.com/strands-agents/harness-sdk/releases/tag/python%2Fv1.42.0',
+  packageUrl: 'https://pypi.org/project/strands-agents/1.42.0/',
+  entries: [
+    {
+      type: 'feat', breaking: false, scope: 'model', areas: ['model'], title: 'plumb cache tokens',
+      pr: 2287, prUrl: 'https://github.com/strands-agents/sdk-python/pull/2287',
+      commit: '155239d', commitUrl: 'https://github.com/strands-agents/sdk-python/commit/155239d', author: 'yatszhash',
+    },
+  ],
+}
+
+test('renders valid frontmatter markdown', () => {
+  const md = renderMarkdown(file)
+  assert.match(md, /^---\n/)
+  assert.match(md, /\nsdk: harness\n/)
+  assert.match(md, /\nlanguage: python\n/)
+  assert.match(md, /\nversion: "1\.42\.0"\n/)
+  assert.match(md, /\ntag: python\/v1\.42\.0\n/)
+  assert.match(md, /type: feat/)
+  assert.match(md, /areas: \[model\]/)
+  assert.match(md, /title: "plumb cache tokens"/)
+  assert.doesNotMatch(md, /highlights:/) // none provided
+})
+
+test('evals omits language key', () => {
+  const md = renderMarkdown({
+    ...file, sdk: 'evals', language: undefined, tag: 'v0.2.1', version: '0.2.1',
+    releaseUrl: 'https://github.com/strands-agents/evals/releases/tag/v0.2.1',
+    packageUrl: 'https://pypi.org/project/strands-agents-evals/0.2.1/',
+  })
+  assert.doesNotMatch(md, /\nlanguage:/)
+})
+
+test('empty entries renders entries: []', () => {
+  assert.match(renderMarkdown({ ...file, entries: [] }), /\nentries: \[\]\n/)
+})
+
+test('quotes all-digit commit so YAML keeps it a string', () => {
+  const md = renderMarkdown({
+    ...file,
+    entries: [{ ...file.entries[0], commit: '1122334', commitUrl: 'https://github.com/o/r/commit/1122334' }],
+  })
+  assert.match(md, /commit: "1122334"/)
+})
+
+test('null pr/commit/author render as null', () => {
+  const md = renderMarkdown({
+    ...file,
+    entries: [{ type: 'feat', breaking: false, scope: null, areas: [], title: 'x', pr: null, prUrl: null, commit: null, commitUrl: null, author: null }],
+  })
+  assert.match(md, /pr: null/)
+  assert.match(md, /commit: null/)
+  assert.match(md, /author: null/)
+  assert.match(md, /scope: null/)
+})
+
+test('mergePreserving keeps existing highlights + body, refreshes entries', () => {
+  const existing = `---
+sdk: harness
+language: python
+version: "1.42.0"
+tag: python/v1.42.0
+date: 2026-06-01
+releaseUrl: https://example/r
+packageUrl: https://example/p
+highlights: |
+  Hand written summary.
+entries: []
+---
+
+Some curated prose body.`
+  const merged = mergePreserving(file, existing)
+  assert.match(merged, /highlights: \|/)
+  assert.match(merged, /Hand written summary\./)
+  assert.match(merged, /Some curated prose body\./)
+  assert.match(merged, /plumb cache tokens/) // entries refreshed from fresh file
+})
+
+test('mergePreserving with no existing file just renders fresh', () => {
+  const merged = mergePreserving(file, null)
+  assert.equal(merged, renderMarkdown(file))
+})

--- a/changelog-release-pr/scripts/render-markdown.test.cjs
+++ b/changelog-release-pr/scripts/render-markdown.test.cjs
@@ -61,6 +61,32 @@ test('null pr/commit/author render as null', () => {
   assert.match(md, /scope: null/)
 })
 
+test('quotes areas that contain YAML-significant chars', () => {
+  const md = renderMarkdown({
+    ...file,
+    entries: [{ ...file.entries[0], areas: ['model', 'a,b', 'weird]bracket', 'has space'] }],
+  })
+  // commas/brackets/spaces inside a label must be quoted so the flow seq stays valid
+  assert.match(md, /areas: \[model, "a,b", "weird\]bracket", "has space"\]/)
+})
+
+test('quotes YAML reserved bool/null words in scope and areas', () => {
+  const md = renderMarkdown({
+    ...file,
+    entries: [{ ...file.entries[0], scope: 'on', areas: ['yes', 'null', 'model'] }],
+  })
+  assert.match(md, /scope: "on"/)
+  assert.match(md, /areas: \["yes", "null", model\]/)
+})
+
+test('escapes quotes and newlines in titles', () => {
+  const md = renderMarkdown({
+    ...file,
+    entries: [{ ...file.entries[0], title: 'add "quoted" thing' }],
+  })
+  assert.match(md, /title: "add \\"quoted\\" thing"/)
+})
+
 test('mergePreserving keeps existing highlights + body, refreshes entries', () => {
   const existing = `---
 sdk: harness

--- a/changelog-release-pr/scripts/render-markdown.test.cjs
+++ b/changelog-release-pr/scripts/render-markdown.test.cjs
@@ -87,6 +87,12 @@ test('escapes quotes and newlines in titles', () => {
   assert.match(md, /title: "add \\"quoted\\" thing"/)
 })
 
+test('renders newContributors when present, omits when empty', () => {
+  const md = renderMarkdown({ ...file, newContributors: [{ login: 'newdev', pr: 2700 }, { login: 'other-dev', pr: 2701 }] })
+  assert.match(md, /newContributors:\n  - \{ login: newdev, pr: 2700 \}\n  - \{ login: other-dev, pr: 2701 \}/)
+  assert.doesNotMatch(renderMarkdown(file), /newContributors/)
+})
+
 test('mergePreserving keeps existing highlights + body, refreshes entries', () => {
   const existing = `---
 sdk: harness

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -44,8 +44,11 @@ async function runAction(github, context, core) {
           user: pr.user ? pr.user.login : null,
         }
       } catch (e) {
-        if (e.status === 404) return null
-        throw e
+        // 404 (deleted PR) and transient errors (403 rate-limit, 5xx) should
+        // degrade this one entry, not abort a whole backfill. Enrichment is
+        // best-effort; the next sync re-enriches.
+        if (e.status !== 404) core.warning(`PR ${repoFull}#${num}: ${e.status || e.message} — skipping enrichment`)
+        return null
       }
     },
   }
@@ -71,9 +74,12 @@ async function runAction(github, context, core) {
 
   core.info(`changelog: wrote ${result.written.length} file(s)`)
   for (const w of result.warnings) core.warning(w)
-  // Expose for the PR body.
+  // Expose for the PR body + a git-safe branch name (tags contain '/' and '.').
+  const sdkSlug = sourceRepo.endsWith('/evals') ? 'evals' : 'harness'
+  const tagSlug = (tag || 'backfill').replace(/[^A-Za-z0-9._-]+/g, '-')
   core.setOutput('written_count', String(result.written.length))
   core.setOutput('warnings', result.warnings.join('\n'))
+  core.setOutput('branch', `changelog/sync-${sdkSlug}-${tagSlug}`)
   return result
 }
 

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -19,6 +19,11 @@ async function runAction(github, context, core) {
   const targetDir = process.env.TARGET_DIR
   const skipExisting = process.env.SKIP_EXISTING === 'true'
 
+  if (mode === 'single' && !tag) {
+    core.setFailed('changelog: single mode requires a tag (got none). Pass the release tag or use mode: backfill.')
+    return { written: [], warnings: [] }
+  }
+
   const client = {
     listReleases: async (repoFull) => {
       const { owner, repo } = splitRepo(repoFull)
@@ -90,11 +95,13 @@ async function runAction(github, context, core) {
   core.info(`changelog: wrote ${result.written.length} file(s)`)
   for (const w of result.warnings) core.warning(w)
   // Expose for the PR body + a git-safe branch name (tags contain '/' and '.').
-  const sdkSlug = sourceRepo.endsWith('/evals') ? 'evals' : 'harness'
+  // Slug from the repo NAME so different source repos (harness-sdk vs the
+  // archived sdk-typescript) can never collide on the same backfill branch.
+  const repoSlug = sourceRepo.split('/')[1] || sourceRepo
   const tagSlug = (tag || 'backfill').replace(/[^A-Za-z0-9._-]+/g, '-')
   core.setOutput('written_count', String(result.written.length))
   core.setOutput('warnings', result.warnings.join('\n'))
-  core.setOutput('branch', `changelog/sync-${sdkSlug}-${tagSlug}`)
+  core.setOutput('branch', `changelog/sync-${repoSlug}-${tagSlug}`)
   return result
 }
 

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -98,7 +98,8 @@ async function runAction(github, context, core) {
   // archived sdk-typescript) can never collide on the same backfill branch.
   const repoSlug = sourceRepo.split('/')[1] || sourceRepo
   const tagSlug = (tag || 'backfill').replace(/[^A-Za-z0-9._-]+/g, '-')
-  core.setOutput('written_count', String(result.written.length))
+  // Only `branch` and `warnings` are consumed by the composite action (PR
+  // branch + body); the written count is already logged via core.info above.
   core.setOutput('warnings', result.warnings.join('\n'))
   core.setOutput('branch', `changelog/sync-${repoSlug}-${tagSlug}`)
   return result

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -69,6 +69,39 @@ async function runAction(github, context, core) {
         return null
       }
     },
+    // Tags for prior-tag-in-stream detection.
+    listTags: async (repoFull) => {
+      const { owner, repo } = splitRepo(repoFull)
+      const tags = await github.paginate(github.rest.repos.listTags, { owner, repo, per_page: 100 })
+      return tags.map((t) => ({ name: t.name, commitSha: t.commit && t.commit.sha }))
+    },
+    // Merged commits between two tags. GitHub caps a compare at 250 commits;
+    // total_commits tells us when the list is truncated so callers can warn.
+    compareCommits: async (repoFull, base, head) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await github.rest.repos.compareCommitsWithBasehead({ owner, repo, basehead: `${base}...${head}`, per_page: 100 })
+        const data = res.data
+        const commits = (data.commits || []).map((c) => ({ sha: c.sha, message: c.commit && c.commit.message }))
+        return { commits, truncated: typeof data.total_commits === 'number' && data.total_commits > commits.length }
+      } catch (e) {
+        core.warning(`compare ${repoFull} ${base}...${head}: ${e.status || e.message} — no entries derived`)
+        return { commits: [], truncated: false }
+      }
+    },
+    // PRs associated with a commit (authoritative; handles squash + merge).
+    commitPulls: async (repoFull, sha) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha: sha, per_page: 100 })
+        return (res.data || [])
+          .filter((pr) => pr.merged_at) // only merged PRs
+          .map((pr) => ({ number: pr.number, title: pr.title, user: pr.user ? pr.user.login : null }))
+      } catch (e) {
+        if (e.status !== 404) core.warning(`commit ${repoFull}@${sha} pulls: ${e.status || e.message} — skipped`)
+        return []
+      }
+    },
   }
 
   const result = await run({

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -5,6 +5,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const crypto = require('crypto')
 const { run } = require('./run.cjs')
 
 function splitRepo(full) {
@@ -144,13 +145,46 @@ async function runAction(github, context, core) {
   // Expose for the PR body + a git-safe branch name (tags contain '/' and '.').
   // Slug from the repo NAME so different source repos (harness-sdk vs the
   // archived sdk-typescript) can never collide on the same backfill branch.
-  const repoSlug = sourceRepo.split('/')[1] || sourceRepo
-  const tagSlug = (tag || 'backfill').replace(/[^A-Za-z0-9._-]+/g, '-')
   // Only `branch` and `warnings` are consumed by the composite action (PR
   // branch + body); the written count is already logged via core.info above.
   core.setOutput('warnings', result.warnings.join('\n'))
-  core.setOutput('branch', `changelog/sync-${repoSlug}-${tagSlug}`)
+  core.setOutput('branch', branchName(sourceRepo, tag, result.written))
   return result
 }
 
+/**
+ * Git-safe PR branch name for a sync run. Slug from the repo NAME so different
+ * source repos (harness-sdk vs the archived sdk-typescript) can never collide.
+ *
+ * In single mode the tag is unique, so it identifies the branch. In backfill
+ * mode there's no tag — a constant ('backfill') would make every run reuse one
+ * branch, so an open-but-unmerged PR from one run would be clobbered by the next
+ * (especially via push-to-fork, where the branch lives on the fork). Hash the
+ * SET of written files instead. `written` is the set of releases NOT yet on the
+ * checked-out base (the PR target), so it equals the PR's content: a re-run that
+ * regenerates the same pending release(s) hashes identically and UPDATES the
+ * open PR; a run whose pending set differs gets a distinct branch (a separate,
+ * independent PR). Caveat: if more releases become pending while an earlier PR
+ * is still open, the grown set hashes differently and opens a second PR — which
+ * is correct for backfill-opens-one-PR semantics and self-heals once merged.
+ * Empty `written` (nothing new) hashes to a constant, but with no file changes
+ * create-pull-request no-ops, so that branch never materializes.
+ *
+ * @param {string} sourceRepo owner/repo
+ * @param {string} tag release tag, or '' / undefined for backfill
+ * @param {string[]} written paths written this run (order-independent)
+ */
+function branchName(sourceRepo, tag, written) {
+  const repoSlug = sourceRepo.split('/')[1] || sourceRepo
+  let suffix
+  if (tag) {
+    suffix = tag.replace(/[^A-Za-z0-9._-]+/g, '-')
+  } else {
+    const fingerprint = [...written].sort().join('\n')
+    suffix = `backfill-${crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 12)}`
+  }
+  return `changelog/sync-${repoSlug}-${suffix}`
+}
+
 module.exports = runAction
+module.exports.branchName = branchName

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -39,11 +39,24 @@ async function runAction(github, context, core) {
       try {
         const res = await github.rest.pulls.get({ owner, repo, pull_number: num })
         const pr = res.data
-        return {
+        const out = {
           labels: (pr.labels || []).map((l) => l.name),
           merge_commit_sha: pr.merge_commit_sha,
           user: pr.user ? pr.user.login : null,
         }
+        // Changed files drive language gating for monorepo releases. Only the
+        // monorepo needs them — pre-monorepo/evals repos are single-language
+        // and build skips filtering there, so don't spend the extra call.
+        if (repoFull === 'strands-agents/harness-sdk') {
+          try {
+            const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: num, per_page: 100 })
+            out.files = files.map((f) => f.filename)
+          } catch (e) {
+            // Leave files undefined → languages null → entry kept everywhere.
+            core.warning(`PR ${repoFull}#${num} files: ${e.status || e.message} — language gating skipped`)
+          }
+        }
+        return out
       } catch (e) {
         // 404 (deleted PR) and transient errors (403 rate-limit, 5xx) should
         // degrade this one entry, not abort a whole backfill. Enrichment is

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -75,15 +75,30 @@ async function runAction(github, context, core) {
       const tags = await github.paginate(github.rest.repos.listTags, { owner, repo, per_page: 100 })
       return tags.map((t) => ({ name: t.name, commitSha: t.commit && t.commit.sha }))
     },
-    // Merged commits between two tags. GitHub caps a compare at 250 commits;
-    // total_commits tells us when the list is truncated so callers can warn.
+    // Merged commits between two tags. The compare endpoint returns its
+    // `commits` array one 100-item page at a time, so we MUST paginate — a
+    // single call would silently drop every commit past the first 100 and
+    // produce an incomplete changelog. We walk all pages via the iterator
+    // (accumulating commits) and read `total_commits` from the first page to
+    // detect GitHub's hard 250-commit cap, beyond which the range genuinely
+    // can't be fully expanded and callers should warn.
     compareCommits: async (repoFull, base, head) => {
       const { owner, repo } = splitRepo(repoFull)
       try {
-        const res = await github.rest.repos.compareCommitsWithBasehead({ owner, repo, basehead: `${base}...${head}`, per_page: 100 })
-        const data = res.data
-        const commits = (data.commits || []).map((c) => ({ sha: c.sha, message: c.commit && c.commit.message }))
-        return { commits, truncated: typeof data.total_commits === 'number' && data.total_commits > commits.length }
+        const commits = []
+        let total = null
+        for await (const page of github.paginate.iterator(github.rest.repos.compareCommitsWithBasehead, {
+          owner,
+          repo,
+          basehead: `${base}...${head}`,
+          per_page: 100,
+        })) {
+          if (total === null && typeof page.data.total_commits === 'number') total = page.data.total_commits
+          for (const c of page.data.commits || []) commits.push({ sha: c.sha, message: c.commit && c.commit.message })
+        }
+        // total_commits is capped at 250 by GitHub; if it reports more than we
+        // could collect, the tail is genuinely unavailable from this endpoint.
+        return { commits, truncated: typeof total === 'number' && total > commits.length }
       } catch (e) {
         core.warning(`compare ${repoFull} ${base}...${head}: ${e.status || e.message} — no entries derived`)
         return { commits: [], truncated: false }

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -49,17 +49,16 @@ async function runAction(github, context, core) {
           merge_commit_sha: pr.merge_commit_sha,
           user: pr.user ? pr.user.login : null,
         }
-        // Changed files drive language gating for monorepo releases. Only the
-        // monorepo needs them — pre-monorepo/evals repos are single-language
-        // and build skips filtering there, so don't spend the extra call.
-        if (repoFull === 'strands-agents/harness-sdk') {
-          try {
-            const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: num, per_page: 100 })
-            out.files = files.map((f) => f.filename)
-          } catch (e) {
-            // Leave files undefined → languages null → entry kept everywhere.
-            core.warning(`PR ${repoFull}#${num} files: ${e.status || e.message} — language gating skipped`)
-          }
+        // Changed files drive two gates: language gating (monorepo) and the
+        // docs-only drop (all streams, incl. pre-monorepo/evals). So fetch
+        // files for every repo now — a docs/blog-only PR is filtered out
+        // everywhere, which needs file info on single-language repos too.
+        try {
+          const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: num, per_page: 100 })
+          out.files = files.map((f) => f.filename)
+        } catch (e) {
+          // Leave files undefined → languages null, docsOnly false → entry kept.
+          core.warning(`PR ${repoFull}#${num} files: ${e.status || e.message} — gating skipped`)
         }
         return out
       } catch (e) {

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -1,0 +1,80 @@
+// github-script entry: assumes `github` (Octokit), `context`, and `core` are
+// provided by actions/github-script (same convention as process-input.cjs).
+// Builds a real client + fs ops and delegates to run.cjs. Inputs come from env
+// (set by the composite action): SOURCE_REPO, MODE, TAG, TARGET_DIR.
+
+const fs = require('fs')
+const path = require('path')
+const { run } = require('./run.cjs')
+
+function splitRepo(full) {
+  const [owner, repo] = full.split('/')
+  return { owner, repo }
+}
+
+async function runAction(github, context, core) {
+  const sourceRepo = process.env.SOURCE_REPO
+  const mode = process.env.MODE === 'backfill' ? 'backfill' : 'single'
+  const tag = process.env.TAG || undefined
+  const targetDir = process.env.TARGET_DIR
+
+  const client = {
+    listReleases: async (repoFull) => {
+      const { owner, repo } = splitRepo(repoFull)
+      return github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 100 })
+    },
+    getRelease: async (repoFull, t) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await github.rest.repos.getReleaseByTag({ owner, repo, tag: t })
+        return res.data
+      } catch (e) {
+        if (e.status === 404) return null
+        throw e
+      }
+    },
+    getPr: async (repoFull, num) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await github.rest.pulls.get({ owner, repo, pull_number: num })
+        const pr = res.data
+        return {
+          labels: (pr.labels || []).map((l) => l.name),
+          merge_commit_sha: pr.merge_commit_sha,
+          user: pr.user ? pr.user.login : null,
+        }
+      } catch (e) {
+        if (e.status === 404) return null
+        throw e
+      }
+    },
+  }
+
+  const result = await run({
+    repo: sourceRepo,
+    mode,
+    tag,
+    client,
+    readExisting: async (p) => {
+      try {
+        return fs.readFileSync(path.join(targetDir, p), 'utf8')
+      } catch {
+        return null
+      }
+    },
+    writeFile: async (p, contents) => {
+      const full = path.join(targetDir, p)
+      fs.mkdirSync(path.dirname(full), { recursive: true })
+      fs.writeFileSync(full, contents)
+    },
+  })
+
+  core.info(`changelog: wrote ${result.written.length} file(s)`)
+  for (const w of result.warnings) core.warning(w)
+  // Expose for the PR body.
+  core.setOutput('written_count', String(result.written.length))
+  core.setOutput('warnings', result.warnings.join('\n'))
+  return result
+}
+
+module.exports = runAction

--- a/changelog-release-pr/scripts/run-action.cjs
+++ b/changelog-release-pr/scripts/run-action.cjs
@@ -17,6 +17,7 @@ async function runAction(github, context, core) {
   const mode = process.env.MODE === 'backfill' ? 'backfill' : 'single'
   const tag = process.env.TAG || undefined
   const targetDir = process.env.TARGET_DIR
+  const skipExisting = process.env.SKIP_EXISTING === 'true'
 
   const client = {
     listReleases: async (repoFull) => {
@@ -57,6 +58,7 @@ async function runAction(github, context, core) {
     repo: sourceRepo,
     mode,
     tag,
+    skipExisting,
     client,
     readExisting: async (p) => {
       try {

--- a/changelog-release-pr/scripts/run-action.test.cjs
+++ b/changelog-release-pr/scripts/run-action.test.cjs
@@ -1,0 +1,39 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { branchName } = require('./run-action.cjs')
+
+test('single mode: branch is keyed by the (git-sanitized) tag', () => {
+  assert.equal(
+    branchName('strands-agents/harness-sdk', 'python/v1.43.0', []),
+    'changelog/sync-harness-sdk-python-v1.43.0'
+  )
+})
+
+test('branch slug comes from the repo name, not the owner', () => {
+  // Archived sdk-typescript and harness-sdk must never collide on one branch.
+  assert.match(branchName('strands-agents/sdk-typescript', 'v0.1.0', []), /^changelog\/sync-sdk-typescript-/)
+})
+
+test('backfill mode: branch is a content hash of the written set', () => {
+  const b = branchName('strands-agents/harness-sdk', '', ['a.md', 'b.md'])
+  assert.match(b, /^changelog\/sync-harness-sdk-backfill-[0-9a-f]{12}$/)
+})
+
+test('backfill: same files (any order) → same branch, so a re-run updates one PR', () => {
+  const a = branchName('strands-agents/harness-sdk', '', ['a.md', 'b.md'])
+  const b = branchName('strands-agents/harness-sdk', '', ['b.md', 'a.md'])
+  assert.equal(a, b)
+})
+
+test('backfill: different files → different branch, so independent runs get separate PRs', () => {
+  const week1 = branchName('strands-agents/harness-sdk', '', ['python-v1.43.0.md'])
+  const week2 = branchName('strands-agents/harness-sdk', '', ['python-v1.44.0.md'])
+  assert.notEqual(week1, week2)
+})
+
+test('backfill: undefined tag is treated the same as empty (hash path)', () => {
+  assert.equal(
+    branchName('strands-agents/harness-sdk', undefined, ['a.md']),
+    branchName('strands-agents/harness-sdk', '', ['a.md'])
+  )
+})

--- a/changelog-release-pr/scripts/run.cjs
+++ b/changelog-release-pr/scripts/run.cjs
@@ -5,6 +5,9 @@
 
 const { buildReleaseFile } = require('./build-release-file.cjs')
 const { enrichFromPr } = require('./enrich.cjs')
+const { deriveEntries, previousTagInStream } = require('./derive-entries.cjs')
+const { tagToMeta } = require('./tag-meta.cjs')
+const { compareVersionDesc } = require('./semver-compare.cjs')
 
 /**
  * @param {{
@@ -43,7 +46,43 @@ async function run(opts) {
     return prCache.get(key)
   }
 
+  // Resolve the prior tag (same stream) to diff each release against.
+  // Backfill: derive it from the already-fetched release list (no extra tag
+  // listing). Single: query tags via previousTagInStream. Cached per tag.
+  const priorCache = new Map()
+  const streamKey = (m) => (m ? `${m.sdk}:${m.language ?? ''}` : null)
+  let backfillPrior = null
+  if (opts.mode === 'backfill') {
+    // Group in-scope release tags by stream, newest-first, so each release's
+    // predecessor is the next one down in its own stream.
+    backfillPrior = new Map()
+    const byStream = new Map()
+    for (const r of releases) {
+      const m = tagToMeta(opts.repo, r.tag_name)
+      const k = streamKey(m)
+      if (!k) continue
+      if (!byStream.has(k)) byStream.set(k, [])
+      byStream.get(k).push({ tag: r.tag_name, version: m.version })
+    }
+    for (const list of byStream.values()) {
+      list.sort((a, b) => compareVersionDesc(a.version, b.version)) // newest-first
+      for (let i = 0; i < list.length; i++) {
+        backfillPrior.set(list[i].tag, list[i + 1] ? list[i + 1].tag : null)
+      }
+    }
+  }
+  const priorTagFor = async (tag) => {
+    if (priorCache.has(tag)) return priorCache.get(tag)
+    const prior = backfillPrior ? backfillPrior.get(tag) ?? null : await previousTagInStream(opts.repo, tag, opts.client)
+    priorCache.set(tag, prior)
+    return prior
+  }
+
   const deps = {
+    deriveEntries: async (repo, release) => {
+      const base = await priorTagFor(release.tag_name)
+      return deriveEntries({ repo, base, head: release.tag_name, client: opts.client })
+    },
     enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, getPr),
     readExisting: opts.readExisting,
     skipExisting: opts.skipExisting === true,

--- a/changelog-release-pr/scripts/run.cjs
+++ b/changelog-release-pr/scripts/run.cjs
@@ -19,26 +19,37 @@ const { enrichFromPr } = require('./enrich.cjs')
  * @returns {Promise<{written:string[], warnings:string[]}>}
  */
 async function run(opts) {
+  const warnings = []
   let releases
   if (opts.mode === 'backfill') {
     releases = await opts.client.listReleases(opts.repo)
   } else {
     const r = await opts.client.getRelease(opts.repo, opts.tag)
     releases = r ? [r] : []
+    if (!r) warnings.push(`${opts.repo}: no release found for tag "${opts.tag || ''}" — nothing to sync.`)
   }
 
-  // listReleases includes drafts (no published_at) — skip them; a changelog
-  // only covers published releases.
-  releases = releases.filter((r) => r && r.published_at)
+  // Skip drafts (no published_at) and prereleases — the changelog covers
+  // published, stable releases only.
+  releases = releases.filter((r) => r && r.published_at && !r.prerelease)
+
+  // Memoize PR fetches: a first-time contributor's PR usually also appears in
+  // "What's Changed", and on the monorepo each fetch includes a paginated file
+  // list — caching roughly halves API spend on a backfill.
+  const prCache = new Map()
+  const getPr = (repo, num) => {
+    const key = `${repo}#${num}`
+    if (!prCache.has(key)) prCache.set(key, opts.client.getPr(repo, num))
+    return prCache.get(key)
+  }
 
   const deps = {
-    enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, opts.client.getPr),
+    enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, getPr),
     readExisting: opts.readExisting,
     skipExisting: opts.skipExisting === true,
   }
 
   const written = []
-  const warnings = []
   for (const release of releases) {
     const built = await buildReleaseFile(opts.repo, release, deps)
     if (!built) continue

--- a/changelog-release-pr/scripts/run.cjs
+++ b/changelog-release-pr/scripts/run.cjs
@@ -26,6 +26,10 @@ async function run(opts) {
     releases = r ? [r] : []
   }
 
+  // listReleases includes drafts (no published_at) — skip them; a changelog
+  // only covers published releases.
+  releases = releases.filter((r) => r && r.published_at)
+
   const deps = {
     enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, opts.client.getPr),
     readExisting: opts.readExisting,

--- a/changelog-release-pr/scripts/run.cjs
+++ b/changelog-release-pr/scripts/run.cjs
@@ -11,6 +11,7 @@ const { enrichFromPr } = require('./enrich.cjs')
  *   repo:string,
  *   mode:'single'|'backfill',
  *   tag?:string,
+ *   skipExisting?:boolean,
  *   client:{ listReleases:(repo:string)=>Promise<any[]>, getRelease:(repo:string,tag:string)=>Promise<any|null>, getPr:(repo:string,num:number)=>Promise<any|null> },
  *   readExisting:(path:string)=>Promise<string|null>,
  *   writeFile:(path:string,contents:string)=>Promise<void>,
@@ -33,6 +34,7 @@ async function run(opts) {
   const deps = {
     enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, opts.client.getPr),
     readExisting: opts.readExisting,
+    skipExisting: opts.skipExisting === true,
   }
 
   const written = []

--- a/changelog-release-pr/scripts/run.cjs
+++ b/changelog-release-pr/scripts/run.cjs
@@ -1,0 +1,46 @@
+// Entry-point logic: pick releases (single tag or full backfill), build each
+// into a file, write it, and collect any format-drift warnings. Pure given an
+// injected client + fs ops, so it's unit-testable. The github-script wrapper
+// (run-action.cjs) supplies a real client built from Octokit + node:fs.
+
+const { buildReleaseFile } = require('./build-release-file.cjs')
+const { enrichFromPr } = require('./enrich.cjs')
+
+/**
+ * @param {{
+ *   repo:string,
+ *   mode:'single'|'backfill',
+ *   tag?:string,
+ *   client:{ listReleases:(repo:string)=>Promise<any[]>, getRelease:(repo:string,tag:string)=>Promise<any|null>, getPr:(repo:string,num:number)=>Promise<any|null> },
+ *   readExisting:(path:string)=>Promise<string|null>,
+ *   writeFile:(path:string,contents:string)=>Promise<void>,
+ * }} opts
+ * @returns {Promise<{written:string[], warnings:string[]}>}
+ */
+async function run(opts) {
+  let releases
+  if (opts.mode === 'backfill') {
+    releases = await opts.client.listReleases(opts.repo)
+  } else {
+    const r = await opts.client.getRelease(opts.repo, opts.tag)
+    releases = r ? [r] : []
+  }
+
+  const deps = {
+    enrich: (prRepo, pr) => enrichFromPr(prRepo, pr, opts.client.getPr),
+    readExisting: opts.readExisting,
+  }
+
+  const written = []
+  const warnings = []
+  for (const release of releases) {
+    const built = await buildReleaseFile(opts.repo, release, deps)
+    if (!built) continue
+    await opts.writeFile(built.path, built.contents)
+    written.push(built.path)
+    if (built.warning) warnings.push(built.warning)
+  }
+  return { written, warnings }
+}
+
+module.exports = { run }

--- a/changelog-release-pr/scripts/run.test.cjs
+++ b/changelog-release-pr/scripts/run.test.cjs
@@ -1,0 +1,60 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { run } = require('./run.cjs')
+
+const releases = [
+  { tag_name: 'python/v1.42.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h1', body: '* feat: a by @x in https://github.com/strands-agents/sdk-python/pull/1\n' },
+  { tag_name: 'python-wasm/v0.0.1', published_at: '2026-06-02T00:00:00Z', html_url: 'h2', body: '' },
+]
+
+function fakeClient() {
+  return {
+    listReleases: async () => releases,
+    getRelease: async (_r, tag) => releases.find((x) => x.tag_name === tag) || null,
+    getPr: async () => ({ labels: ['area-model'], merge_commit_sha: 'abc1234', user: 'x' }),
+  }
+}
+
+test('backfill writes one file per in-scope release', async () => {
+  const written = {}
+  const res = await run({
+    repo: 'strands-agents/harness-sdk', mode: 'backfill', client: fakeClient(),
+    readExisting: async () => null,
+    writeFile: async (p, c) => { written[p] = c },
+  })
+  assert.deepEqual(Object.keys(written), ['site/src/content/changelog/harness/python-v1.42.0.md'])
+  assert.match(written['site/src/content/changelog/harness/python-v1.42.0.md'], /area-model|area/) // enriched
+  assert.deepEqual(res.warnings, [])
+})
+
+test('single mode writes only the given tag', async () => {
+  const written = {}
+  await run({
+    repo: 'strands-agents/harness-sdk', mode: 'single', tag: 'python/v1.42.0',
+    client: fakeClient(), readExisting: async () => null,
+    writeFile: async (p, c) => { written[p] = c },
+  })
+  assert.deepEqual(Object.keys(written), ['site/src/content/changelog/harness/python-v1.42.0.md'])
+})
+
+test('single mode with unknown tag writes nothing', async () => {
+  const written = {}
+  const res = await run({
+    repo: 'strands-agents/harness-sdk', mode: 'single', tag: 'python/v9.9.9',
+    client: fakeClient(), readExisting: async () => null,
+    writeFile: async (p, c) => { written[p] = c },
+  })
+  assert.deepEqual(Object.keys(written), [])
+  assert.deepEqual(res.written, [])
+})
+
+test('collects drift warnings', async () => {
+  const drifty = [{ tag_name: 'v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '* a #1\n* b #2\n* c #3\n' }]
+  const client = { listReleases: async () => drifty, getRelease: async () => null, getPr: async () => null }
+  const res = await run({
+    repo: 'strands-agents/harness-sdk', mode: 'backfill', client,
+    readExisting: async () => null, writeFile: async () => {},
+  })
+  assert.equal(res.warnings.length, 1)
+  assert.match(res.warnings[0], /parsed 0 of 3/)
+})

--- a/changelog-release-pr/scripts/run.test.cjs
+++ b/changelog-release-pr/scripts/run.test.cjs
@@ -54,7 +54,7 @@ test('single mode writes only the given tag', async () => {
   assert.deepEqual(Object.keys(written), ['site/src/content/changelog/harness/python-v1.42.0.md'])
 })
 
-test('single mode with unknown tag writes nothing', async () => {
+test('single mode with unknown tag writes nothing and warns', async () => {
   const written = {}
   const res = await run({
     repo: 'strands-agents/harness-sdk', mode: 'single', tag: 'python/v9.9.9',
@@ -63,6 +63,36 @@ test('single mode with unknown tag writes nothing', async () => {
   })
   assert.deepEqual(Object.keys(written), [])
   assert.deepEqual(res.written, [])
+  assert.match(res.warnings[0], /no release found for tag "python\/v9\.9\.9"/)
+})
+
+test('prereleases are skipped', async () => {
+  const pre = [{ tag_name: 'v2.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h', prerelease: true, body: '* feat: x by @a in https://github.com/o/r/pull/1\n' }]
+  const client = { listReleases: async () => pre, getRelease: async () => null, getPr: async () => null }
+  const res = await run({
+    repo: 'strands-agents/evals', mode: 'backfill', client,
+    readExisting: async () => null, writeFile: async () => { throw new Error('must not write') },
+  })
+  assert.deepEqual(res.written, [])
+})
+
+test('memoizes PR fetches across entries and newContributors', async () => {
+  let prCalls = 0
+  const rel = [{
+    tag_name: 'python/v9.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h',
+    body: [
+      '* feat: thing by @newdev in https://github.com/strands-agents/harness-sdk/pull/7',
+      '',
+      '## New Contributors',
+      '* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/7',
+    ].join('\n'),
+  }]
+  const client = {
+    listReleases: async () => rel, getRelease: async () => null,
+    getPr: async () => { prCalls++; return { labels: [], merge_commit_sha: 'abc1234', user: 'newdev', files: ['strands-py/x.py'] } },
+  }
+  await run({ repo: 'strands-agents/harness-sdk', mode: 'backfill', client, readExisting: async () => null, writeFile: async () => {} })
+  assert.equal(prCalls, 1) // entry + contributor gating share one fetch
 })
 
 test('skips draft releases (null published_at) without crashing', async () => {

--- a/changelog-release-pr/scripts/run.test.cjs
+++ b/changelog-release-pr/scripts/run.test.cjs
@@ -2,43 +2,56 @@ const { test } = require('node:test')
 const assert = require('node:assert/strict')
 const { run } = require('./run.cjs')
 
+// Entries are now sourced from the compare API (commits between the prior tag
+// and this one, each resolved to a PR), not parsed from the release body. The
+// fake client below provides listReleases/getRelease plus the compare surface:
+// listTags (prior-tag detection), compareCommits, and commitPulls.
+
 const releases = [
-  { tag_name: 'python/v1.42.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h1', body: '* feat: a by @x in https://github.com/strands-agents/sdk-python/pull/1\n' },
+  { tag_name: 'python/v1.42.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h1', body: '' },
+  { tag_name: 'python/v1.41.0', published_at: '2026-05-21T00:00:00Z', html_url: 'h0', body: '' },
   { tag_name: 'python-wasm/v0.0.1', published_at: '2026-06-02T00:00:00Z', html_url: 'h2', body: '' },
 ]
 
-function fakeClient() {
+function fakeClient(overrides = {}) {
   return {
     listReleases: async () => releases,
     getRelease: async (_r, tag) => releases.find((x) => x.tag_name === tag) || null,
-    getPr: async () => ({ labels: ['area-model'], merge_commit_sha: 'abc1234', user: 'x' }),
+    listTags: async () => releases.map((r) => ({ name: r.tag_name })),
+    // One PR (#1) merged between v1.41.0 and v1.42.0.
+    compareCommits: async (_r, base, head) =>
+      base === 'python/v1.41.0' && head === 'python/v1.42.0'
+        ? { commits: [{ sha: 's1' }], truncated: false }
+        : { commits: [], truncated: false },
+    commitPulls: async (_r, sha) => (sha === 's1' ? [{ number: 1, title: 'feat: a', user: 'x' }] : []),
+    getPr: async () => ({ labels: ['area-model'], merge_commit_sha: 'abc1234', user: 'x', files: ['strands-py/a.py'] }),
+    ...overrides,
   }
 }
 
-test('backfill writes one file per in-scope release', async () => {
+test('backfill writes one file per in-scope release with compare-derived entries', async () => {
   const written = {}
   const res = await run({
     repo: 'strands-agents/harness-sdk', mode: 'backfill', client: fakeClient(),
     readExisting: async () => null,
     writeFile: async (p, c) => { written[p] = c },
   })
-  assert.deepEqual(Object.keys(written), ['site/src/content/changelog/harness/python-v1.42.0.md'])
+  // python-wasm is out of scope; v1.41.0 is the first in-scope release (no prior
+  // tag → no entries) but still gets a file; v1.42.0 gets the derived entry.
+  assert.ok(written['site/src/content/changelog/harness/python-v1.42.0.md'])
+  assert.match(written['site/src/content/changelog/harness/python-v1.42.0.md'], /title: "a"/)
   // enrichment landed: area-model label → areas: [model]
   assert.match(written['site/src/content/changelog/harness/python-v1.42.0.md'], /areas: \[model\]/)
-  assert.deepEqual(res.warnings, [])
+  assert.ok(!Object.keys(written).some((p) => p.includes('wasm')))
 })
 
 test('skipExisting skips releases with files and never calls enrichment for them', async () => {
   let prCalls = 0
-  const client = {
-    ...fakeClient(),
-    getPr: async () => { prCalls++; return { labels: [], merge_commit_sha: 'abc1234', user: 'x' } },
-  }
-  const written = {}
+  const client = fakeClient({ getPr: async () => { prCalls++; return { labels: [], merge_commit_sha: 'abc1234', user: 'x' } } })
   const res = await run({
     repo: 'strands-agents/harness-sdk', mode: 'backfill', skipExisting: true, client,
     readExisting: async () => '---\nsdk: harness\n---\n', // every file already exists
-    writeFile: async (p, c) => { written[p] = c },
+    writeFile: async () => {},
   })
   assert.deepEqual(res.written, [])
   assert.equal(prCalls, 0) // existence checked BEFORE enrichment
@@ -67,8 +80,8 @@ test('single mode with unknown tag writes nothing and warns', async () => {
 })
 
 test('prereleases are skipped', async () => {
-  const pre = [{ tag_name: 'v2.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h', prerelease: true, body: '* feat: x by @a in https://github.com/o/r/pull/1\n' }]
-  const client = { listReleases: async () => pre, getRelease: async () => null, getPr: async () => null }
+  const pre = [{ tag_name: 'v2.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h', prerelease: true, body: '' }]
+  const client = fakeClient({ listReleases: async () => pre, getRelease: async () => null })
   const res = await run({
     repo: 'strands-agents/evals', mode: 'backfill', client,
     readExisting: async () => null, writeFile: async () => { throw new Error('must not write') },
@@ -78,29 +91,30 @@ test('prereleases are skipped', async () => {
 
 test('memoizes PR fetches across entries and newContributors', async () => {
   let prCalls = 0
-  const rel = [{
-    tag_name: 'python/v9.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h',
-    body: [
-      '* feat: thing by @newdev in https://github.com/strands-agents/harness-sdk/pull/7',
-      '',
-      '## New Contributors',
-      '* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/7',
-    ].join('\n'),
-  }]
-  const client = {
-    listReleases: async () => rel, getRelease: async () => null,
+  const rel = [
+    { tag_name: 'python/v9.0.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h',
+      body: '## New Contributors\n* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/7' },
+    { tag_name: 'python/v8.9.0', published_at: '2026-05-01T00:00:00Z', html_url: 'h0', body: '' },
+  ]
+  const client = fakeClient({
+    listReleases: async () => rel,
+    getRelease: async () => null,
+    listTags: async () => rel.map((r) => ({ name: r.tag_name })),
+    compareCommits: async (_r, base, head) =>
+      head === 'python/v9.0.0' ? { commits: [{ sha: 's7' }], truncated: false } : { commits: [], truncated: false },
+    commitPulls: async (_r, sha) => (sha === 's7' ? [{ number: 7, title: 'feat: thing', user: 'newdev' }] : []),
     getPr: async () => { prCalls++; return { labels: [], merge_commit_sha: 'abc1234', user: 'newdev', files: ['strands-py/x.py'] } },
-  }
+  })
   await run({ repo: 'strands-agents/harness-sdk', mode: 'backfill', client, readExisting: async () => null, writeFile: async () => {} })
-  assert.equal(prCalls, 1) // entry + contributor gating share one fetch
+  assert.equal(prCalls, 1) // entry (#7) + contributor (#7) gating share one fetch
 })
 
 test('skips draft releases (null published_at) without crashing', async () => {
   const withDraft = [
-    { tag_name: 'v1.0.0', published_at: null, html_url: 'h', body: '* feat: x by @a in https://github.com/o/r/pull/1\n' },
-    { tag_name: 'v0.9.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '* fix: y by @b in https://github.com/o/r/pull/2\n' },
+    { tag_name: 'v1.0.0', published_at: null, html_url: 'h', body: '' },
+    { tag_name: 'v0.9.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '' },
   ]
-  const client = { listReleases: async () => withDraft, getRelease: async () => null, getPr: async () => null }
+  const client = fakeClient({ listReleases: async () => withDraft, getRelease: async () => null, listTags: async () => withDraft.map((r) => ({ name: r.tag_name })) })
   const written = {}
   const res = await run({
     repo: 'strands-agents/evals', mode: 'backfill', client,
@@ -110,13 +124,20 @@ test('skips draft releases (null published_at) without crashing', async () => {
   assert.deepEqual(res.written, ['site/src/content/changelog/evals/v0.9.0.md'])
 })
 
-test('collects drift warnings', async () => {
-  const drifty = [{ tag_name: 'v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '* a #1\n* b #2\n* c #3\n' }]
-  const client = { listReleases: async () => drifty, getRelease: async () => null, getPr: async () => null }
+test('surfaces a truncated-compare warning', async () => {
+  const rel = [
+    { tag_name: 'python/v2.0.0', published_at: '2026-01-02T00:00:00Z', html_url: 'h', body: '' },
+    { tag_name: 'python/v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h0', body: '' },
+  ]
+  const client = fakeClient({
+    listReleases: async () => rel, getRelease: async () => null,
+    listTags: async () => rel.map((r) => ({ name: r.tag_name })),
+    compareCommits: async () => ({ commits: [{ sha: 's1' }], truncated: true }),
+    commitPulls: async () => [{ number: 1, title: 'feat: x', user: 'a' }],
+  })
   const res = await run({
     repo: 'strands-agents/harness-sdk', mode: 'backfill', client,
     readExisting: async () => null, writeFile: async () => {},
   })
-  assert.equal(res.warnings.length, 1)
-  assert.match(res.warnings[0], /parsed 0 of 3/)
+  assert.ok(res.warnings.some((w) => /250-commit cap/.test(w)))
 })

--- a/changelog-release-pr/scripts/run.test.cjs
+++ b/changelog-release-pr/scripts/run.test.cjs
@@ -48,6 +48,21 @@ test('single mode with unknown tag writes nothing', async () => {
   assert.deepEqual(res.written, [])
 })
 
+test('skips draft releases (null published_at) without crashing', async () => {
+  const withDraft = [
+    { tag_name: 'v1.0.0', published_at: null, html_url: 'h', body: '* feat: x by @a in https://github.com/o/r/pull/1\n' },
+    { tag_name: 'v0.9.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '* fix: y by @b in https://github.com/o/r/pull/2\n' },
+  ]
+  const client = { listReleases: async () => withDraft, getRelease: async () => null, getPr: async () => null }
+  const written = {}
+  const res = await run({
+    repo: 'strands-agents/evals', mode: 'backfill', client,
+    readExisting: async () => null, writeFile: async (p, c) => { written[p] = c },
+  })
+  // only the published one is written
+  assert.deepEqual(res.written, ['site/src/content/changelog/evals/v0.9.0.md'])
+})
+
 test('collects drift warnings', async () => {
   const drifty = [{ tag_name: 'v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '* a #1\n* b #2\n* c #3\n' }]
   const client = { listReleases: async () => drifty, getRelease: async () => null, getPr: async () => null }

--- a/changelog-release-pr/scripts/run.test.cjs
+++ b/changelog-release-pr/scripts/run.test.cjs
@@ -23,8 +23,25 @@ test('backfill writes one file per in-scope release', async () => {
     writeFile: async (p, c) => { written[p] = c },
   })
   assert.deepEqual(Object.keys(written), ['site/src/content/changelog/harness/python-v1.42.0.md'])
-  assert.match(written['site/src/content/changelog/harness/python-v1.42.0.md'], /area-model|area/) // enriched
+  // enrichment landed: area-model label → areas: [model]
+  assert.match(written['site/src/content/changelog/harness/python-v1.42.0.md'], /areas: \[model\]/)
   assert.deepEqual(res.warnings, [])
+})
+
+test('skipExisting skips releases with files and never calls enrichment for them', async () => {
+  let prCalls = 0
+  const client = {
+    ...fakeClient(),
+    getPr: async () => { prCalls++; return { labels: [], merge_commit_sha: 'abc1234', user: 'x' } },
+  }
+  const written = {}
+  const res = await run({
+    repo: 'strands-agents/harness-sdk', mode: 'backfill', skipExisting: true, client,
+    readExisting: async () => '---\nsdk: harness\n---\n', // every file already exists
+    writeFile: async (p, c) => { written[p] = c },
+  })
+  assert.deepEqual(res.written, [])
+  assert.equal(prCalls, 0) // existence checked BEFORE enrichment
 })
 
 test('single mode writes only the given tag', async () => {

--- a/changelog-release-pr/scripts/semver-compare.cjs
+++ b/changelog-release-pr/scripts/semver-compare.cjs
@@ -1,7 +1,9 @@
 // Compare two version strings newest-first, with prerelease (rc) handling.
-// Ported from the docs site's util/changelog.ts compareVersionDesc — kept as a
-// small self-contained copy so this action stays dependency-free (the two
+// Ported from harness-sdk site/src/util/changelog.ts compareVersionDesc — kept
+// as a small self-contained copy so this action stays dependency-free (the two
 // packages don't share a module). Used to find the previous tag in a stream.
+// KEEP IN SYNC with that copy: the ordering rules (esp. prerelease handling)
+// must match, or backfill and the rendered site disagree on release order.
 //
 // Returns <0 if `a` is newer than `b` (so ascending .sort() puts newest first):
 //   1.0.0 > 1.0.0-rc.1 > 1.0.0-rc.0, and 1.10.0 > 1.9.0 (numeric, not lexical).

--- a/changelog-release-pr/scripts/semver-compare.cjs
+++ b/changelog-release-pr/scripts/semver-compare.cjs
@@ -1,0 +1,36 @@
+// Compare two version strings newest-first, with prerelease (rc) handling.
+// Ported from the docs site's util/changelog.ts compareVersionDesc — kept as a
+// small self-contained copy so this action stays dependency-free (the two
+// packages don't share a module). Used to find the previous tag in a stream.
+//
+// Returns <0 if `a` is newer than `b` (so ascending .sort() puts newest first):
+//   1.0.0 > 1.0.0-rc.1 > 1.0.0-rc.0, and 1.10.0 > 1.9.0 (numeric, not lexical).
+
+function compareVersionDesc(a, b) {
+  const parse = (v) => {
+    const [core = '', pre] = String(v).replace(/^v/, '').split('-')
+    return { core: core.split('.').map((n) => parseInt(n, 10) || 0), pre: pre ? pre.split('.') : null }
+  }
+  const pa = parse(a)
+  const pb = parse(b)
+  for (let i = 0; i < Math.max(pa.core.length, pb.core.length); i++) {
+    const d = (pb.core[i] ?? 0) - (pa.core[i] ?? 0)
+    if (d !== 0) return d
+  }
+  // Same core: a release (no prerelease) is newer than any prerelease of it.
+  if (!pa.pre && pb.pre) return -1
+  if (pa.pre && !pb.pre) return 1
+  if (pa.pre && pb.pre) {
+    for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
+      const x = pa.pre[i] ?? ''
+      const y = pb.pre[i] ?? ''
+      const nx = Number(x)
+      const ny = Number(y)
+      const d = Number.isNaN(nx) || Number.isNaN(ny) ? y.localeCompare(x) : ny - nx
+      if (d !== 0) return d
+    }
+  }
+  return 0
+}
+
+module.exports = { compareVersionDesc }

--- a/changelog-release-pr/scripts/semver-compare.test.cjs
+++ b/changelog-release-pr/scripts/semver-compare.test.cjs
@@ -1,0 +1,25 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { compareVersionDesc } = require('./semver-compare.cjs')
+
+test('orders versions newest-first', () => {
+  const sorted = ['1.0.0-rc.0', '1.0.0', '1.0.0-rc.1', '1.2.0'].sort(compareVersionDesc)
+  assert.deepEqual(sorted, ['1.2.0', '1.0.0', '1.0.0-rc.1', '1.0.0-rc.0'])
+})
+
+test('numeric core comparison, not lexical (1.10.0 > 1.9.0)', () => {
+  assert.ok(compareVersionDesc('1.10.0', '1.9.0') < 0)
+  assert.deepEqual(['1.9.0', '1.10.0', '1.2.0'].sort(compareVersionDesc), ['1.10.0', '1.9.0', '1.2.0'])
+})
+
+test('a final release ranks above its prereleases', () => {
+  assert.ok(compareVersionDesc('1.0.0', '1.0.0-rc.5') < 0)
+})
+
+test('prerelease numbers compare numerically (rc.10 > rc.2)', () => {
+  assert.ok(compareVersionDesc('1.0.0-rc.10', '1.0.0-rc.2') < 0)
+})
+
+test('tolerates a leading v and equal versions', () => {
+  assert.equal(compareVersionDesc('v1.2.3', '1.2.3'), 0)
+})

--- a/changelog-release-pr/scripts/tag-meta.cjs
+++ b/changelog-release-pr/scripts/tag-meta.cjs
@@ -1,0 +1,50 @@
+// Map a repo + release tag to changelog metadata, and build package-registry URLs.
+// Pure, dependency-free. Mirrors site/src/config/changelog.ts (Plan 1 contract).
+
+function cleanVersion(raw) {
+  // Strip a leading 'v' and any stray dot after it (handles 'v.1.2.0').
+  return raw.replace(/^v\.?/, '')
+}
+
+/**
+ * @param {string} repo  e.g. 'strands-agents/harness-sdk' | 'strands-agents/evals'
+ * @param {string} tag   the release tag
+ * @returns {{sdk:'harness'|'evals', language:'python'|'typescript'|undefined, version:string}|null}
+ */
+function tagToMeta(repo, tag) {
+  const isEvals = repo.endsWith('/evals')
+  if (isEvals) {
+    // Evals is python-only; accept bare vX or python/vX.
+    const m = tag.match(/(?:^|\/)v\.?(\d.*)$/)
+    if (!m) return null
+    return { sdk: 'evals', language: undefined, version: cleanVersion('v' + m[1]) }
+  }
+  // harness-sdk
+  if (tag.startsWith('python-wasm/')) return null
+  if (tag.startsWith('python/')) {
+    return { sdk: 'harness', language: 'python', version: cleanVersion(tag.slice('python/'.length)) }
+  }
+  if (tag.startsWith('typescript/')) {
+    return { sdk: 'harness', language: 'typescript', version: cleanVersion(tag.slice('typescript/'.length)) }
+  }
+  if (/^v\.?\d/.test(tag)) {
+    return { sdk: 'harness', language: 'python', version: cleanVersion(tag) }
+  }
+  return null
+}
+
+const pypi = (name, v) => `https://pypi.org/project/${name}/${v}/`
+const npm = (name, v) => `https://www.npmjs.com/package/${name}/v/${v}`
+
+/**
+ * @param {'harness'|'evals'} sdk
+ * @param {'python'|'typescript'|undefined} language
+ * @param {string} version
+ */
+function getPackageUrl(sdk, language, version) {
+  if (sdk === 'evals') return pypi('strands-agents-evals', version)
+  if (language === 'typescript') return npm('@strands-agents/sdk', version)
+  return pypi('strands-agents', version)
+}
+
+module.exports = { tagToMeta, getPackageUrl }

--- a/changelog-release-pr/scripts/tag-meta.cjs
+++ b/changelog-release-pr/scripts/tag-meta.cjs
@@ -19,6 +19,12 @@ function tagToMeta(repo, tag) {
     if (!m) return null
     return { sdk: 'evals', language: undefined, version: cleanVersion('v' + m[1]) }
   }
+  // The archived pre-monorepo TypeScript repo: all its releases are
+  // harness/typescript history (used only by the one-time backfill).
+  if (repo.endsWith('/sdk-typescript')) {
+    if (!/^v\.?\d/.test(tag)) return null
+    return { sdk: 'harness', language: 'typescript', version: cleanVersion(tag) }
+  }
   // harness-sdk
   if (tag.startsWith('python-wasm/')) return null
   if (tag.startsWith('python/')) {

--- a/changelog-release-pr/scripts/tag-meta.test.cjs
+++ b/changelog-release-pr/scripts/tag-meta.test.cjs
@@ -1,0 +1,49 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { tagToMeta, getPackageUrl } = require('./tag-meta.cjs')
+
+test('harness python prefixed tag', () => {
+  assert.deepEqual(tagToMeta('strands-agents/harness-sdk', 'python/v1.42.0'), {
+    sdk: 'harness', language: 'python', version: '1.42.0',
+  })
+})
+
+test('harness typescript prefixed tag', () => {
+  assert.deepEqual(tagToMeta('strands-agents/harness-sdk', 'typescript/v1.4.0'), {
+    sdk: 'harness', language: 'typescript', version: '1.4.0',
+  })
+})
+
+test('harness bare v tag is pre-monorepo python', () => {
+  assert.deepEqual(tagToMeta('strands-agents/harness-sdk', 'v1.9.1'), {
+    sdk: 'harness', language: 'python', version: '1.9.1',
+  })
+})
+
+test('evals bare v tag is python-only (no language)', () => {
+  assert.deepEqual(tagToMeta('strands-agents/evals', 'v0.2.1'), {
+    sdk: 'evals', language: undefined, version: '0.2.1',
+  })
+})
+
+test('evals python-prefixed tag also maps to evals python', () => {
+  assert.deepEqual(tagToMeta('strands-agents/evals', 'python/v0.1.3'), {
+    sdk: 'evals', language: undefined, version: '0.1.3',
+  })
+})
+
+test('malformed typescript tag still parses', () => {
+  assert.deepEqual(tagToMeta('strands-agents/harness-sdk', 'typescript/v.1.2.0'), {
+    sdk: 'harness', language: 'typescript', version: '1.2.0',
+  })
+})
+
+test('python-wasm is skipped (null)', () => {
+  assert.equal(tagToMeta('strands-agents/harness-sdk', 'python-wasm/v0.0.1'), null)
+})
+
+test('package urls', () => {
+  assert.equal(getPackageUrl('harness', 'python', '1.42.0'), 'https://pypi.org/project/strands-agents/1.42.0/')
+  assert.equal(getPackageUrl('harness', 'typescript', '1.4.0'), 'https://www.npmjs.com/package/@strands-agents/sdk/v/1.4.0')
+  assert.equal(getPackageUrl('evals', undefined, '0.2.1'), 'https://pypi.org/project/strands-agents-evals/0.2.1/')
+})

--- a/changelog-release-pr/scripts/tag-meta.test.cjs
+++ b/changelog-release-pr/scripts/tag-meta.test.cjs
@@ -42,6 +42,16 @@ test('python-wasm is skipped (null)', () => {
   assert.equal(tagToMeta('strands-agents/harness-sdk', 'python-wasm/v0.0.1'), null)
 })
 
+test('archived sdk-typescript repo bare v tags map to harness/typescript', () => {
+  assert.deepEqual(tagToMeta('strands-agents/sdk-typescript', 'v1.3.0'), {
+    sdk: 'harness', language: 'typescript', version: '1.3.0',
+  })
+  // rc tags parse too
+  assert.deepEqual(tagToMeta('strands-agents/sdk-typescript', 'v1.0.0-rc.5'), {
+    sdk: 'harness', language: 'typescript', version: '1.0.0-rc.5',
+  })
+})
+
 test('package urls', () => {
   assert.equal(getPackageUrl('harness', 'python', '1.42.0'), 'https://pypi.org/project/strands-agents/1.42.0/')
   assert.equal(getPackageUrl('harness', 'typescript', '1.4.0'), 'https://www.npmjs.com/package/@strands-agents/sdk/v/1.4.0')


### PR DESCRIPTION
## Description

Adds the `changelog-release-pr/` composite action — the automation half of the Strands changelog feature. It turns GitHub Releases into structured changelog markdown for the harness-sdk docs site ([#2717](https://github.com/strands-agents/harness-sdk/pull/2717)) and opens a PR there.

**Deterministic, no LLM.** Pipeline:
1. Fetch the release(s).
2. Derive structured entries from the GitHub **compare API** — every merged commit between the prior tag (auto-detected, same stream, semver-ordered) and this one, each resolved to its PR via the commit→PR API. This is independent of release-note prose, so it's immune to the note-format drift that broke body-parsing.
3. Enrich each entry from its linked PR: `area-*` labels → areas, `breaking change` label, merge-commit SHA, author, and — for monorepo releases — a changed-file language gate (python vs typescript).
4. Render `site/src/content/changelog/<sdk>/<file>.md` matching the harness-sdk Zod schema, preserving human-written `highlights`/body on re-sync.
5. Open a PR via `peter-evans/create-pull-request`.

Built to devtools house style: dependency-free `.cjs` modules invoked through `actions/github-script`; pure logic with injected fetchers/fs; tests via Node's built-in runner (`node --test`).

### Notable behaviors
- **Compare-API entries**: format-independent breakdown; squash and merge-commit repos both resolve correctly.
- **Language gating** (monorepo): PR changed-files decide the python vs typescript stream (both → both; site/CI/docs-only → omitted; new contributors with neither → kept in both).
- **New Contributors** parsed into structured frontmatter (incl. bracket-suffixed bots like `dependabot[bot]`), never leaked into entries, language-gated like entries.
- **Pre-monorepo / archived repos**: maps `python/v*`, `typescript/v*`, and bare `v*` tags (incl. the archived `sdk-typescript`) to the right stream for the one-time backfill.
- **Fork-based PR flow** (`push-to-fork`): an account without write access to the target repo opens the PR from its own fork; a classic PAT with `public_repo` is sufficient. PRs authored this way (a real user) trigger the required CI Gate, which GITHUB_TOKEN-authored PRs do not.
- **Stable backfill branches**: the backfill branch name is a content hash of the written release set, so an open-but-unmerged sync PR isn't clobbered by a later run carrying a different set of releases.
- **Cheap cron backstop** (`skip-existing`): only generates missing files, never regresses existing enrichment.

### Tests
`cd changelog-release-pr/scripts && node --test` — 87 tests, all green.

### Merge order
First in the stack: **#66 (this) → #2717 → #2761 → #2765**. The sync workflow (#2765) pins this action at `@main`, so this must land first.
