### PR TITLE
fix(reviewer): pass system_prompt_suffix via env to avoid JS injection

### DIFF
--- a/strands-command/actions/strands-input-parser/action.yml
+++ b/strands-command/actions/strands-input-parser/action.yml
@@ -41,6 +41,11 @@ runs:
 
     - name: Process input
       uses: actions/github-script@v8
+      env:
+        # Passed via env, not script interpolation: the suffix is free-form text
+        # (markdown with backticks, ${...}, etc.) that would otherwise break the
+        # surrounding JS template literal and allow script injection.
+        SYSTEM_PROMPT_SUFFIX: ${{ inputs.system_prompt_suffix }}
       with:
         script: |
           const processInput = require('./devtools/strands-command/scripts/javascript/process-input.cjs');
@@ -48,7 +53,7 @@ runs:
             issue_id: '${{ inputs.issue_id }}',
             command: '${{ inputs.command }}',
             session_id: '${{ inputs.session_id }}',
-            system_prompt_suffix: `${{ inputs.system_prompt_suffix }}`
+            system_prompt_suffix: process.env.SYSTEM_PROMPT_SUFFIX
           });
 
     - name: Upload parsed input artifact


### PR DESCRIPTION
## Summary

The `system_prompt_suffix` input (added in #67) is interpolated directly into a `github-script` template literal:

```yaml
system_prompt_suffix: `${{ inputs.system_prompt_suffix }}`
```

Any suffix containing a backtick — e.g. ordinary markdown like `` `site/` `` — terminates the template literal early and throws at parse time:

```
SyntaxError: Unexpected identifier 'site'
```

This takes down the whole `strands-input-parser` step (observed on a consumer repo passing a markdown suffix). The same interpolation is a script-injection vector for any caller-supplied text.

## Fix

Pass the value through an `env:` var and read `process.env.SYSTEM_PROMPT_SUFFIX` inside the script, so the free-form text never becomes part of the JS source. This is GitHub's recommended pattern for untrusted/free-form values in `github-script`.

## Testing

Reproduced the exact `SyntaxError: Unexpected identifier 'site'` by interpolating a backtick-containing suffix into a template literal in Node, and confirmed the env-var path reads the same text with backticks preserved and no parse error.