### PR TITLE
feat(issue-labeler): set native issue type and language field on issues

### DIFF
--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -141,8 +141,7 @@ labels:
 Names (`Bug`, `Language`, `Python`) are resolved to GitHub node IDs at runtime
 via a repo-level GraphQL query and matched case-insensitively. Unmatched names
 emit a warning and are skipped, and never fail the workflow. Existing values
-are always overwritten. The action's existing `issues: write` permission is
-sufficient.
+are always overwritten. The action's existing `issues: write` permission is expected to cover these mutations; verify against a test issue before rolling out broadly.
 
 ## Inputs
 

--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -102,6 +102,7 @@ labels:
     description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama)"
   # Shorthand form:
   area-tool: "Tool behavior, execution, @tool decorator"
+```
 
 ### Setting native issue type and issue fields (issues only)
 

--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -106,7 +106,7 @@ labels:
 ### Setting native issue type and issue fields (issues only)
 
 In addition to labels, the action can set the org's native **issue type** and a
-single-select **issue field** — but only when triggered by an `issues` event
+single-select **issue field**, but only when triggered by an `issues` event
 (these features do not apply to pull requests). This is additive: labels are
 still applied exactly as before.
 
@@ -139,10 +139,9 @@ labels:
 
 Names (`Bug`, `Language`, `Python`) are resolved to GitHub node IDs at runtime
 via a repo-level GraphQL query and matched case-insensitively. Unmatched names
-emit a warning and are skipped — they never fail the workflow. Existing values
+emit a warning and are skipped, and never fail the workflow. Existing values
 are always overwritten. The action's existing `issues: write` permission is
 sufficient.
-```
 
 ## Inputs
 

--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -102,6 +102,46 @@ labels:
     description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama)"
   # Shorthand form:
   area-tool: "Tool behavior, execution, @tool decorator"
+
+### Setting native issue type and issue fields (issues only)
+
+In addition to labels, the action can set the org's native **issue type** and a
+single-select **issue field** — but only when triggered by an `issues` event
+(these features do not apply to pull requests). This is additive: labels are
+still applied exactly as before.
+
+Add a `type:` key to a label to map it to a native issue type:
+
+```yaml
+labels:
+  bug:
+    description: "Something is broken"
+    type: Bug          # native issue type name (resolved at runtime)
+  enhancement:
+    description: "New feature or improvement"
+    type: Feature
+```
+
+Add a top-level `field:` block plus per-label `option:` keys to set a
+single-select issue field:
+
+```yaml
+field:
+  name: Language       # issue field name (resolved at runtime)
+labels:
+  python:
+    description: "Python SDK"
+    option: Python     # single-select option name
+  typescript:
+    description: "TypeScript SDK"
+    option: TypeScript
+```
+
+Names (`Bug`, `Language`, `Python`) are resolved to GitHub node IDs at runtime
+via a repo-level GraphQL query and matched case-insensitively. Unmatched names
+emit a warning and are skipped — they never fail the workflow. Existing values
+are always overwritten. The action's existing `issues: write` permission is
+sufficient.
 ```
 
 ## Inputs
@@ -130,3 +170,27 @@ labels:
 2. The role needs `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` permissions
 3. Bedrock access enabled for the configured model in `aws_region`
 4. The labels referenced in your config must already exist on the repo
+
+## Backfilling existing issues
+
+`backfill.py` applies the same native type/field logic to existing issues. For
+each issue it reuses an existing type/language label when present, and only
+calls the LLM for issues missing one. Run locally with `gh` authenticated and
+AWS credentials available:
+
+```bash
+pip install --upgrade strands-agents pyyaml "boto3>=1.35.0"
+
+# Dry run first (prints intended changes, writes nothing):
+python3 backfill.py --repo strands-agents/harness-sdk \
+  --type-config path/to/type.yml \
+  --language-config path/to/language.yml \
+  --dry-run
+
+# Apply (all issues, open and closed, by default):
+python3 backfill.py --repo strands-agents/harness-sdk \
+  --type-config path/to/type.yml \
+  --language-config path/to/language.yml
+```
+
+For Python-only repos (e.g. evals) omit `--language-config`.

--- a/issue-labeler/README.md
+++ b/issue-labeler/README.md
@@ -107,9 +107,9 @@ labels:
 ### Setting native issue type and issue fields (issues only)
 
 In addition to labels, the action can set the org's native **issue type** and a
-single-select **issue field**, but only when triggered by an `issues` event
-(these features do not apply to pull requests). This is additive: labels are
-still applied exactly as before.
+single-select **issue field**, whenever the triggering event carries an issue
+payload (these features do not apply to pull requests). This is additive:
+labels are still applied exactly as before.
 
 Add a `type:` key to a label to map it to a native issue type:
 
@@ -139,9 +139,12 @@ labels:
 ```
 
 Names (`Bug`, `Language`, `Python`) are resolved to GitHub node IDs at runtime
-via a repo-level GraphQL query and matched case-insensitively. Unmatched names
-emit a warning and are skipped, and never fail the workflow. Existing values
-are always overwritten. The action's existing `issues: write` permission is expected to cover these mutations; verify against a test issue before rolling out broadly.
+via a repo-level GraphQL query and matched case-insensitively. A malformed
+`field:` block fails the run (like a malformed `labels:` block); after that,
+unmatched names or API errors emit a warning and are skipped, and never fail
+the workflow. Existing values are always overwritten. The action's existing
+`issues: write` permission is expected to cover these mutations; verify
+against a test issue before rolling out broadly.
 
 ## Inputs
 
@@ -174,8 +177,11 @@ are always overwritten. The action's existing `issues: write` permission is expe
 
 `backfill.py` applies the same native type/field logic to existing issues. For
 each issue it reuses an existing type/language label when present, and only
-calls the LLM for issues missing one. Run locally with `gh` authenticated and
-AWS credentials available:
+calls the LLM for issues missing one; freshly classified labels are applied to
+the issue so re-runs reuse them. The run aborts up front if the configured
+type/field/option names don't resolve on the repo, and exits non-zero listing
+any issues whose updates failed. Run locally with `gh` authenticated and AWS
+credentials available:
 
 ```bash
 pip install --upgrade strands-agents pyyaml "boto3>=1.35.0"

--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -92,6 +92,11 @@ runs:
         ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
         ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
         ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        # Set only when the event payload carries a real issue (issue_comment
+        # events on PRs also expose github.event.issue, so exclude those):
+        # gates the native type/field update and saves classify.py a lookup
+        # for the node ID that mutations need.
+        ISSUE_NODE_ID: ${{ (!github.event.issue.pull_request && github.event.issue.node_id) || '' }}
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         CONFIG_PATH: ${{ steps.config.outputs.path }}
@@ -99,5 +104,4 @@ runs:
         AWS_REGION: ${{ inputs.aws_region }}
         MAX_LABELS: ${{ inputs.max_labels }}
         MAX_BODY_LENGTH: ${{ inputs.max_body_length }}
-        EVENT_NAME: ${{ github.event_name }}
       run: python3 "${{ github.action_path }}/classify.py"

--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -99,4 +99,5 @@ runs:
         AWS_REGION: ${{ inputs.aws_region }}
         MAX_LABELS: ${{ inputs.max_labels }}
         MAX_BODY_LENGTH: ${{ inputs.max_body_length }}
+        EVENT_NAME: ${{ github.event_name }}
       run: python3 "${{ github.action_path }}/classify.py"

--- a/issue-labeler/backfill.py
+++ b/issue-labeler/backfill.py
@@ -28,6 +28,8 @@ from classify import (
     parse_label_type_map,
     resolve_native_ids,
     sanitize,
+    select_option,
+    select_type,
 )
 
 
@@ -92,6 +94,9 @@ def main():
     issues = list_issues(args.repo, args.state)
     print(f"Backfilling {len(issues)} issue(s) on {args.repo} (dry_run={args.dry_run})")
 
+    # Resolve native type/field IDs once for the whole run (same for every issue).
+    native = resolve_native_ids(args.repo)
+
     for issue in issues:
         number = str(issue["number"])
         title = sanitize(issue.get("title", ""), 200)
@@ -120,12 +125,15 @@ def main():
             continue
 
         if args.dry_run:
-            wanted_type = type_map.get(effective_labels[0]) if type_map else None
+            wanted_type = select_type(effective_labels, type_map) if type_map else None
+            wanted_option = (
+                select_option(effective_labels, field_config["option_map"]) if field_config else None
+            )
             print(f"#{number}: would apply labels={effective_labels} "
-                  f"type={wanted_type} (field via {field_config['name'] if field_config else None})")
+                  f"type={wanted_type} field={wanted_option}")
             continue
 
-        apply_native_targets(number, args.repo, effective_labels, type_map, field_config)
+        apply_native_targets(number, args.repo, effective_labels, type_map, field_config, native=native)
         print(f"#{number}: applied")
 
 

--- a/issue-labeler/backfill.py
+++ b/issue-labeler/backfill.py
@@ -4,7 +4,9 @@
 Reuses the classification logic from classify.py. For each issue:
 - If it already carries a label from the relevant allowlist (e.g. `bug`,
   `python`), map directly from that label -- no LLM call.
-- Otherwise classify the issue with the same config the action uses.
+- Otherwise classify the issue with the same config the action uses, and apply
+  the classified label to the issue so re-runs reuse it instead of paying for
+  another LLM call.
 
 Run locally with `gh` authenticated and AWS credentials available for Bedrock.
 
@@ -20,6 +22,7 @@ import subprocess
 import sys
 
 from classify import (
+    apply_labels,
     apply_native_targets,
     build_system_prompt,
     classify_issue,
@@ -28,34 +31,72 @@ from classify import (
     parse_label_type_map,
     resolve_native_ids,
     sanitize,
-    select_option,
-    select_type,
+    select_native_targets,
 )
 
+LIST_LIMIT = 10000
 
-def decide_label(existing_labels, allowlist, classify_fn):
-    """Reuse an existing allowlisted label if present, else classify."""
+
+def decide_label(existing_labels, allowlist, mapping, classify_fn):
+    """Pick the label that drives the native mapping for one dimension.
+
+    Prefers an existing label that actually maps to a native target (an
+    unmapped allowlisted label like `question` must not shadow a mapped one),
+    then any allowlisted label (already classified, nothing to map), and only
+    calls the LLM when the issue has no allowlisted label at all.
+
+    Returns (label, classified) where classified is True when the label came
+    from the LLM rather than an existing label.
+    """
+    for label in existing_labels:
+        if label in mapping:
+            return label, False
     for label in existing_labels:
         if label in allowlist:
-            return label
+            return label, False
     classified = classify_fn()
-    return classified[0] if classified else None
+    return (classified[0] if classified else None), True
 
 
 def list_issues(repo, state):
-    """Return all issues (number, title, body, label names) for the repo."""
+    """Return all issues (number, node id, title, body, label names) for the repo."""
     result = subprocess.run(
         ["gh", "issue", "list", "--repo", repo, "--state", state,
-         "--limit", "10000", "--json", "number,title,body,labels"],
+         "--limit", str(LIST_LIMIT), "--json", "id,number,title,body,labels"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
         print(f"::error::Failed to list issues: {result.stderr}")
         sys.exit(1)
     issues = json.loads(result.stdout)
+    if len(issues) >= LIST_LIMIT:
+        print(f"::warning::Hit the {LIST_LIMIT}-issue list limit; issues beyond it were NOT fetched.")
     for issue in issues:
         issue["label_names"] = [lbl["name"] for lbl in issue.get("labels", [])]
     return issues
+
+
+def check_native_coverage(native, type_map, field_config):
+    """Fail fast when configured mappings cannot resolve to native IDs.
+
+    Without this, a failed/underprivileged resolution burns an LLM call per
+    issue and mutates nothing while the per-issue warnings scroll by.
+    """
+    problems = []
+    if type_map:
+        missing = sorted({t for t in type_map.values() if t.lower() not in native["types"]})
+        if missing:
+            problems.append(f"issue type(s) not found on repo: {', '.join(missing)}")
+    if field_config:
+        field = native["fields"].get(field_config["name"].lower())
+        if field is None:
+            problems.append(f"single-select field '{field_config['name']}' not found on repo")
+        else:
+            missing = sorted({o for o in field_config["option_map"].values()
+                              if o.lower() not in field["options"]})
+            if missing:
+                problems.append(f"option(s) not on field '{field_config['name']}': {', '.join(missing)}")
+    return problems
 
 
 def main():
@@ -72,31 +113,38 @@ def main():
 
     # Load configs and derive the mappings + classification prompts.
     type_map = {}
-    type_allowlist = frozenset()
-    type_prompt = None
-    type_config = None
-    if args.type_config:
-        type_config = load_config(args.type_config)
-        type_map = parse_label_type_map(type_config)
-        type_allowlist = frozenset(type_config["labels"].keys())
-        type_prompt = build_system_prompt(type_config, max_labels=1)
-
     field_config = None
-    lang_allowlist = frozenset()
-    lang_prompt = None
-    lang_config = None
+    dimensions = []  # (dimension_name, allowlist, mapping, prompt)
+    if args.type_config:
+        config = load_config(args.type_config)
+        type_map = parse_label_type_map(config)
+        dimensions.append(("type", frozenset(config["labels"].keys()), type_map,
+                           build_system_prompt(config, max_labels=1)))
     if args.language_config:
-        lang_config = load_config(args.language_config)
-        field_config = parse_field_config(lang_config)
-        lang_allowlist = frozenset(lang_config["labels"].keys())
-        lang_prompt = build_system_prompt(lang_config, max_labels=1)
+        config = load_config(args.language_config)
+        try:
+            field_config = parse_field_config(config)
+        except ValueError as e:
+            print(f"::error::{e}")
+            sys.exit(1)
+        option_map = field_config["option_map"] if field_config else {}
+        dimensions.append(("language", frozenset(config["labels"].keys()), option_map,
+                           build_system_prompt(config, max_labels=1)))
 
     issues = list_issues(args.repo, args.state)
     print(f"Backfilling {len(issues)} issue(s) on {args.repo} (dry_run={args.dry_run})")
 
-    # Resolve native type/field IDs once for the whole run (same for every issue).
+    # Resolve native type/field IDs once for the whole run (same for every
+    # issue) and fail fast if the configured names don't resolve -- otherwise
+    # every issue would burn an LLM call only to warn and mutate nothing.
     native = resolve_native_ids(args.repo)
+    problems = check_native_coverage(native, type_map, field_config)
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        sys.exit(1)
 
+    failed = []
     for issue in issues:
         number = str(issue["number"])
         title = sanitize(issue.get("title", ""), 200)
@@ -105,36 +153,48 @@ def main():
 
         # Determine the effective type/language labels (reuse or classify).
         effective_labels = []
-        if args.type_config:
-            type_label = decide_label(
-                existing, type_allowlist,
-                lambda: classify_issue(title, body, type_prompt, type_allowlist),
+        classified_labels = []
+        for _, allowlist, mapping, prompt in dimensions:
+            label, classified = decide_label(
+                existing, allowlist, mapping,
+                lambda: classify_issue(title, body, prompt, allowlist),
             )
-            if type_label:
-                effective_labels.append(type_label)
-        if args.language_config:
-            lang_label = decide_label(
-                existing, lang_allowlist,
-                lambda: classify_issue(title, body, lang_prompt, lang_allowlist),
-            )
-            if lang_label:
-                effective_labels.append(lang_label)
+            if label:
+                effective_labels.append(label)
+                if classified:
+                    classified_labels.append(label)
 
         if not effective_labels:
             print(f"#{number}: no type/language signal, skipping")
             continue
 
+        wanted_type, wanted_option = select_native_targets(effective_labels, type_map, field_config)
+
         if args.dry_run:
-            wanted_type = select_type(effective_labels, type_map) if type_map else None
-            wanted_option = (
-                select_option(effective_labels, field_config["option_map"]) if field_config else None
-            )
             print(f"#{number}: would apply labels={effective_labels} "
                   f"type={wanted_type} field={wanted_option}")
             continue
 
-        apply_native_targets(number, args.repo, effective_labels, type_map, field_config, native=native)
-        print(f"#{number}: applied")
+        # Apply freshly classified labels so the issue matches action-labeled
+        # issues and re-runs reuse the label instead of re-classifying.
+        ok = True
+        if classified_labels:
+            ok = apply_labels(number, classified_labels, args.repo)
+        ok = apply_native_targets(
+            number, args.repo, effective_labels, type_map, field_config,
+            native=native, node_id=issue.get("id"),
+        ) and ok
+
+        if ok:
+            print(f"#{number}: applied labels={effective_labels} "
+                  f"type={wanted_type} field={wanted_option}")
+        else:
+            failed.append(number)
+            print(f"#{number}: FAILED (see warnings above)")
+
+    if failed:
+        print(f"::error::{len(failed)} issue(s) failed: {', '.join(failed)}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/issue-labeler/backfill.py
+++ b/issue-labeler/backfill.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""One-time backfill of native issue type + language field on existing issues.
+
+Reuses the classification logic from classify.py. For each issue:
+- If it already carries a label from the relevant allowlist (e.g. `bug`,
+  `python`), map directly from that label -- no LLM call.
+- Otherwise classify the issue with the same config the action uses.
+
+Run locally with `gh` authenticated and AWS credentials available for Bedrock.
+
+Examples:
+  python3 backfill.py --repo strands-agents/harness-sdk \\
+    --type-config /path/to/type.yml --language-config /path/to/language.yml --dry-run
+  python3 backfill.py --repo strands-agents/evals --type-config /path/to/type.yml
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+from classify import (
+    apply_native_targets,
+    build_system_prompt,
+    classify_issue,
+    load_config,
+    parse_field_config,
+    parse_label_type_map,
+    resolve_native_ids,
+    sanitize,
+)
+
+
+def decide_label(existing_labels, allowlist, classify_fn):
+    """Reuse an existing allowlisted label if present, else classify."""
+    for label in existing_labels:
+        if label in allowlist:
+            return label
+    classified = classify_fn()
+    return classified[0] if classified else None
+
+
+def list_issues(repo, state):
+    """Return all issues (number, title, body, label names) for the repo."""
+    result = subprocess.run(
+        ["gh", "issue", "list", "--repo", repo, "--state", state,
+         "--limit", "10000", "--json", "number,title,body,labels"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"::error::Failed to list issues: {result.stderr}")
+        sys.exit(1)
+    issues = json.loads(result.stdout)
+    for issue in issues:
+        issue["label_names"] = [lbl["name"] for lbl in issue.get("labels", [])]
+    return issues
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill native issue type/field.")
+    parser.add_argument("--repo", required=True, help="OWNER/NAME")
+    parser.add_argument("--type-config", help="Path to type labeler config (sets native type).")
+    parser.add_argument("--language-config", help="Path to language labeler config (sets field).")
+    parser.add_argument("--state", choices=["all", "open", "closed"], default="all")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not args.type_config and not args.language_config:
+        parser.error("at least one of --type-config / --language-config is required")
+
+    # Load configs and derive the mappings + classification prompts.
+    type_map = {}
+    type_allowlist = frozenset()
+    type_prompt = None
+    type_config = None
+    if args.type_config:
+        type_config = load_config(args.type_config)
+        type_map = parse_label_type_map(type_config)
+        type_allowlist = frozenset(type_config["labels"].keys())
+        type_prompt = build_system_prompt(type_config, max_labels=1)
+
+    field_config = None
+    lang_allowlist = frozenset()
+    lang_prompt = None
+    lang_config = None
+    if args.language_config:
+        lang_config = load_config(args.language_config)
+        field_config = parse_field_config(lang_config)
+        lang_allowlist = frozenset(lang_config["labels"].keys())
+        lang_prompt = build_system_prompt(lang_config, max_labels=1)
+
+    issues = list_issues(args.repo, args.state)
+    print(f"Backfilling {len(issues)} issue(s) on {args.repo} (dry_run={args.dry_run})")
+
+    for issue in issues:
+        number = str(issue["number"])
+        title = sanitize(issue.get("title", ""), 200)
+        body = sanitize(issue.get("body", ""), 1000)
+        existing = issue["label_names"]
+
+        # Determine the effective type/language labels (reuse or classify).
+        effective_labels = []
+        if args.type_config:
+            type_label = decide_label(
+                existing, type_allowlist,
+                lambda: classify_issue(title, body, type_prompt, type_allowlist),
+            )
+            if type_label:
+                effective_labels.append(type_label)
+        if args.language_config:
+            lang_label = decide_label(
+                existing, lang_allowlist,
+                lambda: classify_issue(title, body, lang_prompt, lang_allowlist),
+            )
+            if lang_label:
+                effective_labels.append(lang_label)
+
+        if not effective_labels:
+            print(f"#{number}: no type/language signal, skipping")
+            continue
+
+        if args.dry_run:
+            wanted_type = type_map.get(effective_labels[0]) if type_map else None
+            print(f"#{number}: would apply labels={effective_labels} "
+                  f"type={wanted_type} (field via {field_config['name'] if field_config else None})")
+            continue
+
+        apply_native_targets(number, args.repo, effective_labels, type_map, field_config)
+        print(f"#{number}: applied")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -197,7 +197,7 @@ def set_issue_field(node_id: str, field_id: str, option_id: str) -> None:
         print(f"Set issue field {field_id}: {option_id}")
 
 
-def apply_native_targets(issue_number, repo, labels, type_map, field_config) -> None:
+def apply_native_targets(issue_number: str, repo: str, labels: list, type_map: dict, field_config: dict | None, *, native: dict | None = None) -> None:
     """Map classified labels to a native issue type / field option and apply them.
 
     No-ops (without any network calls) when neither a type nor a field mapping
@@ -210,7 +210,8 @@ def apply_native_targets(issue_number, repo, labels, type_map, field_config) -> 
     if wanted_type is None and wanted_option is None:
         return
 
-    native = resolve_native_ids(repo)
+    if native is None:
+        native = resolve_native_ids(repo)
     node_id = get_issue_node_id(issue_number, repo)
     if not node_id:
         return
@@ -238,7 +239,7 @@ def build_system_prompt(config: dict, max_labels: int) -> str:
     """Build the classification prompt from config."""
     label_lines = []
     for label_name, label_def in config["labels"].items():
-        description = label_def if isinstance(label_def, str) else label_def.get("description", "")
+        description = label_def if isinstance(label_def, str) else _label_def_dict(label_def).get("description", "")
         label_lines.append(f"- {label_name}: {description}")
 
     labels_block = "\n".join(label_lines)

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -372,12 +372,18 @@ def main():
     apply_labels(issue_number, labels)
 
     # Additive: for issues only, also set native issue type / language field.
+    # Best-effort and strictly non-fatal: labels are already applied above, so
+    # any failure here (missing gh, malformed field config, API/permission
+    # error) is downgraded to a warning rather than failing the workflow.
     event_name = os.environ.get("EVENT_NAME", "")
     if event_name == "issues":
-        type_map = parse_label_type_map(config)
-        field_config = parse_field_config(config)
-        if type_map or field_config:
-            apply_native_targets(issue_number, repo, labels, type_map, field_config)
+        try:
+            type_map = parse_label_type_map(config)
+            field_config = parse_field_config(config)
+            if type_map or field_config:
+                apply_native_targets(issue_number, repo, labels, type_map, field_config)
+        except (Exception, SystemExit) as e:  # noqa: BLE001 - additive step must never fail the workflow
+            print(f"::warning::Native type/field update skipped: {e}")
 
     # Write output for downstream steps
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -80,6 +80,40 @@ def parse_field_config(config: dict) -> dict | None:
     return {"name": field_block["name"], "option_map": option_map}
 
 
+def parse_native_ids(graphql_data: dict) -> dict:
+    """Index a resolution-query response into case-insensitive name -> ID maps."""
+    repo = graphql_data.get("repository") or {}
+
+    types = {}
+    for node in (repo.get("issueTypes") or {}).get("nodes", []):
+        types[node["name"].lower()] = node["id"]
+
+    fields = {}
+    for node in (repo.get("issueFields") or {}).get("nodes", []):
+        if node.get("__typename") != "IssueFieldSingleSelect":
+            continue
+        options = {opt["name"].lower(): opt["id"] for opt in node.get("options", [])}
+        fields[node["name"].lower()] = {"id": node["id"], "options": options}
+
+    return {"types": types, "fields": fields}
+
+
+def select_type(labels: list, type_map: dict) -> str | None:
+    """First classified label that maps to a native type name."""
+    for label in labels:
+        if label in type_map:
+            return type_map[label]
+    return None
+
+
+def select_option(labels: list, option_map: dict) -> str | None:
+    """First classified label that maps to a field option name."""
+    for label in labels:
+        if label in option_map:
+            return option_map[label]
+    return None
+
+
 def build_system_prompt(config: dict, max_labels: int) -> str:
     """Build the classification prompt from config."""
     label_lines = []

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -42,6 +42,44 @@ def load_config(config_path: str) -> dict:
     return config
 
 
+def _label_def_dict(label_def) -> dict:
+    """Return the dict form of a label definition, or {} for the shorthand string form."""
+    return label_def if isinstance(label_def, dict) else {}
+
+
+def parse_label_type_map(config: dict) -> dict:
+    """Map label_name -> native issue type name for labels declaring a `type:`."""
+    type_map = {}
+    for label_name, label_def in config["labels"].items():
+        type_name = _label_def_dict(label_def).get("type")
+        if type_name:
+            type_map[label_name] = type_name
+    return type_map
+
+
+def parse_field_config(config: dict) -> dict | None:
+    """Parse the optional top-level `field:` block into {name, option_map}.
+
+    Returns None when no `field:` block is present. option_map maps
+    label_name -> single-select option name for labels declaring an `option:`.
+    """
+    field_block = config.get("field")
+    if field_block is None:
+        return None
+
+    if not isinstance(field_block, dict) or not field_block.get("name"):
+        print("::error::Config 'field' must be a mapping with a non-empty 'name'.")
+        sys.exit(1)
+
+    option_map = {}
+    for label_name, label_def in config["labels"].items():
+        option_name = _label_def_dict(label_def).get("option")
+        if option_name:
+            option_map[label_name] = option_name
+
+    return {"name": field_block["name"], "option_map": option_map}
+
+
 def build_system_prompt(config: dict, max_labels: int) -> str:
     """Build the classification prompt from config."""
     label_lines = []

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -15,6 +15,7 @@ Security model:
 """
 
 import enum
+import json
 import os
 import re
 import subprocess
@@ -112,6 +113,125 @@ def select_option(labels: list, option_map: dict) -> str | None:
         if label in option_map:
             return option_map[label]
     return None
+
+
+_RESOLVE_QUERY = """
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    issueTypes(first: 100) { nodes { id name } }
+    issueFields(first: 100) {
+      nodes {
+        __typename
+        ... on IssueFieldSingleSelect { id name options { id name } }
+      }
+    }
+  }
+}
+"""
+
+
+def resolve_native_ids(repo: str) -> dict:
+    """Query repo-level issue types and single-select fields, return name->ID maps."""
+    owner, name = repo.split("/", 1)
+    result = subprocess.run(
+        ["gh", "api", "graphql",
+         "-f", f"query={_RESOLVE_QUERY}",
+         "-F", f"owner={owner}", "-F", f"name={name}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"::warning::Failed to resolve native type/field IDs: {result.stderr}")
+        return {"types": {}, "fields": {}}
+    try:
+        data = json.loads(result.stdout)["data"]
+    except (ValueError, KeyError) as e:
+        print(f"::warning::Could not parse native ID resolution response: {e}")
+        return {"types": {}, "fields": {}}
+    return parse_native_ids(data)
+
+
+def get_issue_node_id(issue_number: str, repo: str) -> str | None:
+    """Return the GraphQL node ID for an issue (mutations need it, not the number)."""
+    result = subprocess.run(
+        ["gh", "issue", "view", issue_number, "--repo", repo, "--json", "id", "-q", ".id"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"::warning::Could not fetch issue node ID: {result.stderr}")
+        return None
+    return result.stdout.strip() or None
+
+
+def set_issue_type(node_id: str, type_id: str) -> None:
+    mutation = (
+        "mutation($issueId: ID!, $typeId: ID!) {"
+        " updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $typeId})"
+        " { issue { id } } }"
+    )
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={mutation}",
+         "-F", f"issueId={node_id}", "-F", f"typeId={type_id}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"::warning::Failed to set issue type: {result.stderr}")
+    else:
+        print(f"Set issue type: {type_id}")
+
+
+def set_issue_field(node_id: str, field_id: str, option_id: str) -> None:
+    mutation = (
+        "mutation($issueId: ID!, $fieldId: ID!, $optionId: ID!) {"
+        " setIssueFieldValue(input: {issueId: $issueId,"
+        " issueFields: [{fieldId: $fieldId, singleSelectOptionId: $optionId}]})"
+        " { issue { id } } }"
+    )
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={mutation}",
+         "-F", f"issueId={node_id}", "-F", f"fieldId={field_id}", "-F", f"optionId={option_id}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"::warning::Failed to set issue field: {result.stderr}")
+    else:
+        print(f"Set issue field {field_id}: {option_id}")
+
+
+def apply_native_targets(issue_number, repo, labels, type_map, field_config) -> None:
+    """Map classified labels to a native issue type / field option and apply them.
+
+    No-ops (without any network calls) when neither a type nor a field mapping
+    could match the classified labels.
+    """
+    wanted_type = select_type(labels, type_map) if type_map else None
+    wanted_option = (
+        select_option(labels, field_config["option_map"]) if field_config else None
+    )
+    if wanted_type is None and wanted_option is None:
+        return
+
+    native = resolve_native_ids(repo)
+    node_id = get_issue_node_id(issue_number, repo)
+    if not node_id:
+        return
+
+    if wanted_type is not None:
+        type_id = native["types"].get(wanted_type.lower())
+        if type_id:
+            set_issue_type(node_id, type_id)
+        else:
+            print(f"::warning::No native issue type named '{wanted_type}' found on {repo}.")
+
+    if wanted_option is not None:
+        field = native["fields"].get(field_config["name"].lower())
+        if not field:
+            print(f"::warning::No single-select issue field named '{field_config['name']}' found on {repo}.")
+        else:
+            option_id = field["options"].get(wanted_option.lower())
+            if option_id:
+                set_issue_field(node_id, field["id"], option_id)
+            else:
+                print(f"::warning::No option '{wanted_option}' on field '{field_config['name']}'.")
 
 
 def build_system_prompt(config: dict, max_labels: int) -> str:
@@ -223,6 +343,7 @@ def main():
     config_path = os.environ["CONFIG_PATH"]
     max_body_length = int(os.environ.get("MAX_BODY_LENGTH", "1000"))
     max_labels = int(os.environ.get("MAX_LABELS", "3"))
+    repo = os.environ["GH_REPO"]
 
     config = load_config(config_path)
 
@@ -248,6 +369,14 @@ def main():
         sys.exit(0)
 
     apply_labels(issue_number, labels)
+
+    # Additive: for issues only, also set native issue type / language field.
+    event_name = os.environ.get("EVENT_NAME", "")
+    if event_name == "issues":
+        type_map = parse_label_type_map(config)
+        field_config = parse_field_config(config)
+        if type_map or field_config:
+            apply_native_targets(issue_number, repo, labels, type_map, field_config)
 
     # Write output for downstream steps
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/issue-labeler/classify.py
+++ b/issue-labeler/classify.py
@@ -69,8 +69,7 @@ def parse_field_config(config: dict) -> dict | None:
         return None
 
     if not isinstance(field_block, dict) or not field_block.get("name"):
-        print("::error::Config 'field' must be a mapping with a non-empty 'name'.")
-        sys.exit(1)
+        raise ValueError("Config 'field' must be a mapping with a non-empty 'name'.")
 
     option_map = {}
     for label_name, label_def in config["labels"].items():
@@ -99,20 +98,19 @@ def parse_native_ids(graphql_data: dict) -> dict:
     return {"types": types, "fields": fields}
 
 
-def select_type(labels: list, type_map: dict) -> str | None:
-    """First classified label that maps to a native type name."""
+def select_mapped(labels: list, mapping: dict) -> str | None:
+    """Value for the first label present in `mapping`, or None."""
     for label in labels:
-        if label in type_map:
-            return type_map[label]
+        if label in mapping:
+            return mapping[label]
     return None
 
 
-def select_option(labels: list, option_map: dict) -> str | None:
-    """First classified label that maps to a field option name."""
-    for label in labels:
-        if label in option_map:
-            return option_map[label]
-    return None
+def select_native_targets(labels: list, type_map: dict, field_config: dict | None) -> tuple[str | None, str | None]:
+    """Resolve classified labels to (native type name, field option name)."""
+    wanted_type = select_mapped(labels, type_map)
+    wanted_option = select_mapped(labels, field_config["option_map"]) if field_config else None
+    return wanted_type, wanted_option
 
 
 _RESOLVE_QUERY = """
@@ -133,14 +131,11 @@ query($owner: String!, $name: String!) {
 def resolve_native_ids(repo: str) -> dict:
     """Query repo-level issue types and single-select fields, return name->ID maps."""
     owner, name = repo.split("/", 1)
-    result = subprocess.run(
-        ["gh", "api", "graphql",
-         "-f", f"query={_RESOLVE_QUERY}",
-         "-F", f"owner={owner}", "-F", f"name={name}"],
-        capture_output=True, text=True,
+    result = _gh_graphql(
+        _RESOLVE_QUERY, "Failed to resolve native type/field IDs",
+        owner=owner, name=name,
     )
-    if result.returncode != 0:
-        print(f"::warning::Failed to resolve native type/field IDs: {result.stderr}")
+    if result is None:
         return {"types": {}, "fields": {}}
     try:
         data = json.loads(result.stdout)["data"]
@@ -162,77 +157,89 @@ def get_issue_node_id(issue_number: str, repo: str) -> str | None:
     return result.stdout.strip() or None
 
 
-def set_issue_type(node_id: str, type_id: str) -> None:
+def _gh_graphql(query: str, warn_prefix: str, **variables) -> subprocess.CompletedProcess | None:
+    """Run a gh GraphQL call; on failure print a ::warning:: and return None."""
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        cmd += ["-F", f"{key}={value}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"::warning::{warn_prefix}: {result.stderr}")
+        return None
+    return result
+
+
+def set_issue_type(node_id: str, type_id: str) -> bool:
     mutation = (
         "mutation($issueId: ID!, $typeId: ID!) {"
         " updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $typeId})"
         " { issue { id } } }"
     )
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}",
-         "-F", f"issueId={node_id}", "-F", f"typeId={type_id}"],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        print(f"::warning::Failed to set issue type: {result.stderr}")
-    else:
-        print(f"Set issue type: {type_id}")
+    result = _gh_graphql(mutation, "Failed to set issue type", issueId=node_id, typeId=type_id)
+    if result is None:
+        return False
+    print(f"Set issue type: {type_id}")
+    return True
 
 
-def set_issue_field(node_id: str, field_id: str, option_id: str) -> None:
+def set_issue_field(node_id: str, field_id: str, option_id: str) -> bool:
     mutation = (
         "mutation($issueId: ID!, $fieldId: ID!, $optionId: ID!) {"
         " setIssueFieldValue(input: {issueId: $issueId,"
         " issueFields: [{fieldId: $fieldId, singleSelectOptionId: $optionId}]})"
         " { issue { id } } }"
     )
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}",
-         "-F", f"issueId={node_id}", "-F", f"fieldId={field_id}", "-F", f"optionId={option_id}"],
-        capture_output=True, text=True,
+    result = _gh_graphql(
+        mutation, "Failed to set issue field",
+        issueId=node_id, fieldId=field_id, optionId=option_id,
     )
-    if result.returncode != 0:
-        print(f"::warning::Failed to set issue field: {result.stderr}")
-    else:
-        print(f"Set issue field {field_id}: {option_id}")
+    if result is None:
+        return False
+    print(f"Set issue field {field_id}: {option_id}")
+    return True
 
 
-def apply_native_targets(issue_number: str, repo: str, labels: list, type_map: dict, field_config: dict | None, *, native: dict | None = None) -> None:
+def apply_native_targets(issue_number: str, repo: str, labels: list, type_map: dict, field_config: dict | None, *, native: dict | None = None, node_id: str | None = None) -> bool:
     """Map classified labels to a native issue type / field option and apply them.
 
     No-ops (without any network calls) when neither a type nor a field mapping
-    could match the classified labels.
+    could match the classified labels. Returns True only if every wanted
+    mutation succeeded.
     """
-    wanted_type = select_type(labels, type_map) if type_map else None
-    wanted_option = (
-        select_option(labels, field_config["option_map"]) if field_config else None
-    )
+    wanted_type, wanted_option = select_native_targets(labels, type_map, field_config)
     if wanted_type is None and wanted_option is None:
-        return
+        return True
 
     if native is None:
         native = resolve_native_ids(repo)
-    node_id = get_issue_node_id(issue_number, repo)
+    if node_id is None:
+        node_id = get_issue_node_id(issue_number, repo)
     if not node_id:
-        return
+        return False
 
+    ok = True
     if wanted_type is not None:
         type_id = native["types"].get(wanted_type.lower())
         if type_id:
-            set_issue_type(node_id, type_id)
+            ok = set_issue_type(node_id, type_id) and ok
         else:
             print(f"::warning::No native issue type named '{wanted_type}' found on {repo}.")
+            ok = False
 
     if wanted_option is not None:
         field = native["fields"].get(field_config["name"].lower())
         if not field:
             print(f"::warning::No single-select issue field named '{field_config['name']}' found on {repo}.")
+            ok = False
         else:
             option_id = field["options"].get(wanted_option.lower())
             if option_id:
-                set_issue_field(node_id, field["id"], option_id)
+                ok = set_issue_field(node_id, field["id"], option_id) and ok
             else:
                 print(f"::warning::No option '{wanted_option}' on field '{field_config['name']}'.")
+                ok = False
+
+    return ok
 
 
 def build_system_prompt(config: dict, max_labels: int) -> str:
@@ -323,9 +330,8 @@ def classify_issue(title: str, body: str, system_prompt: str, valid_labels: froz
     return labels[:max_labels]
 
 
-def apply_labels(issue_number: str, labels: list[str]) -> None:
+def apply_labels(issue_number: str, labels: list[str], repo: str) -> bool:
     """Apply labels to the issue using gh CLI."""
-    repo = os.environ["GH_REPO"]
     label_csv = ",".join(labels)
 
     print(f"Applying labels to issue #{issue_number}: {label_csv}")
@@ -337,7 +343,8 @@ def apply_labels(issue_number: str, labels: list[str]) -> None:
 
     if result.returncode != 0:
         print(f"::error::Failed to apply labels: {result.stderr}")
-        sys.exit(1)
+        return False
+    return True
 
 
 def main():
@@ -347,6 +354,16 @@ def main():
     repo = os.environ["GH_REPO"]
 
     config = load_config(config_path)
+
+    # Validate the native type/field config up front, so a malformed `field:`
+    # block fails the run loudly (like a malformed `labels:` block) instead of
+    # being swallowed by the best-effort mutation step below.
+    type_map = parse_label_type_map(config)
+    try:
+        field_config = parse_field_config(config)
+    except ValueError as e:
+        print(f"::error::{e}")
+        sys.exit(1)
 
     valid_labels = frozenset(config["labels"].keys())
     print(f"Loaded {len(valid_labels)} valid labels: {sorted(valid_labels)}")
@@ -369,21 +386,24 @@ def main():
         print("No valid labels identified, skipping.")
         sys.exit(0)
 
-    apply_labels(issue_number, labels)
+    if not apply_labels(issue_number, labels, repo):
+        sys.exit(1)
 
     # Additive: for issues only, also set native issue type / language field.
+    # ISSUE_NODE_ID is set by action.yml only when the event payload carries a
+    # real issue (any issue event, not just `issues`), so PRs are excluded.
     # Best-effort and strictly non-fatal: labels are already applied above, so
-    # any failure here (missing gh, malformed field config, API/permission
-    # error) is downgraded to a warning rather than failing the workflow.
-    event_name = os.environ.get("EVENT_NAME", "")
-    if event_name == "issues":
-        try:
-            type_map = parse_label_type_map(config)
-            field_config = parse_field_config(config)
-            if type_map or field_config:
-                apply_native_targets(issue_number, repo, labels, type_map, field_config)
-        except (Exception, SystemExit) as e:  # noqa: BLE001 - additive step must never fail the workflow
-            print(f"::warning::Native type/field update skipped: {e}")
+    # any failure here (missing gh, API/permission error) is downgraded to a
+    # warning rather than failing the workflow.
+    if type_map or field_config:
+        node_id = os.environ.get("ISSUE_NODE_ID", "")
+        if not node_id:
+            print("Event does not target an issue; skipping native type/field update.")
+        else:
+            try:
+                apply_native_targets(issue_number, repo, labels, type_map, field_config, node_id=node_id)
+            except Exception as e:  # noqa: BLE001 - additive step must never fail the workflow
+                print(f"::warning::Native type/field update skipped: {e}")
 
     # Write output for downstream steps
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/issue-labeler/test_backfill.py
+++ b/issue-labeler/test_backfill.py
@@ -3,33 +3,145 @@ import sys
 import backfill
 import pytest
 
-from backfill import decide_label
+from backfill import check_native_coverage, decide_label
 
 
 def test_decide_label_reuses_existing_without_classifying():
     def classify_fn():
         raise AssertionError("must not classify when a label already exists")
-    assert decide_label(["bug", "area-tool"], {"bug", "enhancement"}, classify_fn) == "bug"
+    label, classified = decide_label(
+        ["bug", "area-tool"], {"bug", "enhancement"}, {"bug": "Bug"}, classify_fn)
+    assert label == "bug"
+    assert classified is False
+
+
+def test_decide_label_prefers_mapped_label_over_unmapped():
+    def classify_fn():
+        raise AssertionError("must not classify when a label already exists")
+    # `question` is allowlisted but unmapped; it must not shadow `bug`.
+    label, classified = decide_label(
+        ["question", "bug"], {"question", "bug"}, {"bug": "Bug"}, classify_fn)
+    assert label == "bug"
+    assert classified is False
 
 
 def test_decide_label_classifies_when_missing():
-    assert decide_label(["area-tool"], {"bug", "enhancement"}, lambda: ["enhancement"]) == "enhancement"
+    label, classified = decide_label(
+        ["area-tool"], {"bug", "enhancement"}, {"bug": "Bug"}, lambda: ["enhancement"])
+    assert label == "enhancement"
+    assert classified is True
 
 
 def test_decide_label_none_when_classify_empty():
-    assert decide_label([], {"bug"}, lambda: []) is None
+    label, classified = decide_label([], {"bug"}, {"bug": "Bug"}, lambda: [])
+    assert label is None
+    assert classified is True
+
+
+def test_check_native_coverage_reports_missing_names():
+    native = {"types": {"bug": "IT_bug"}, "fields": {}}
+    problems = check_native_coverage(
+        native,
+        {"bug": "Bug", "enhancement": "Feature"},
+        {"name": "Language", "option_map": {"python": "Python"}},
+    )
+    assert any("Feature" in p for p in problems)
+    assert any("Language" in p for p in problems)
+
+
+def test_check_native_coverage_ok_when_all_resolve():
+    native = {
+        "types": {"bug": "IT_bug"},
+        "fields": {"language": {"id": "IFSS", "options": {"python": "OPT_py"}}},
+    }
+    assert check_native_coverage(
+        native, {"bug": "Bug"},
+        {"name": "Language", "option_map": {"python": "Python"}},
+    ) == []
+
+
+def _run_main(monkeypatch, tmp_path, argv_extra, issues, native):
+    cfg = tmp_path / "type.yml"
+    cfg.write_text('labels:\n  bug:\n    description: "broken"\n    type: Bug\n')
+    monkeypatch.setattr(sys, "argv",
+                        ["backfill.py", "--repo", "o/r", "--type-config", str(cfg)] + argv_extra)
+    monkeypatch.setattr(backfill, "list_issues", lambda repo, state: issues)
+    monkeypatch.setattr(backfill, "resolve_native_ids", lambda repo: native)
+    backfill.main()
+
+
+_NATIVE = {"types": {"bug": "IT_bug"}, "fields": {}}
 
 
 def test_dry_run_does_not_mutate(monkeypatch, tmp_path, capsys):
-    cfg = tmp_path / "type.yml"
-    cfg.write_text('labels:\n  bug:\n    description: "broken"\n    type: Bug\n')
-    monkeypatch.setattr(sys, "argv", ["backfill.py", "--repo", "o/r", "--type-config", str(cfg), "--dry-run"])
-    monkeypatch.setattr(backfill, "list_issues", lambda repo, state: [
-        {"number": 1, "title": "t", "body": "b", "label_names": ["bug"]},
-    ])
-    monkeypatch.setattr(backfill, "resolve_native_ids", lambda repo: {"types": {}, "fields": {}})
-    monkeypatch.setattr(backfill, "apply_native_targets", lambda *a, **k: pytest.fail("must not mutate in dry-run"))
-    backfill.main()
+    monkeypatch.setattr(backfill, "apply_native_targets",
+                        lambda *a, **k: pytest.fail("must not mutate in dry-run"))
+    monkeypatch.setattr(backfill, "apply_labels",
+                        lambda *a, **k: pytest.fail("must not label in dry-run"))
+    _run_main(monkeypatch, tmp_path, ["--dry-run"],
+              [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": ["bug"]}],
+              _NATIVE)
     out = capsys.readouterr().out
-    assert "would apply" in out
-    assert "#1" in out
+    assert "#1: would apply" in out
+    assert "type=Bug" in out
+
+
+def test_aborts_before_llm_when_native_names_missing(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(backfill, "classify_issue",
+                        lambda *a, **k: pytest.fail("must not burn LLM calls when IDs are unresolvable"))
+    with pytest.raises(SystemExit) as excinfo:
+        _run_main(monkeypatch, tmp_path, [],
+                  [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": []}],
+                  {"types": {}, "fields": {}})
+    assert excinfo.value.code == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_applied_summary_reflects_mutation_result(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(backfill, "apply_native_targets", lambda *a, **k: False)
+    with pytest.raises(SystemExit) as excinfo:
+        _run_main(monkeypatch, tmp_path, [],
+                  [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": ["bug"]}],
+                  _NATIVE)
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "#1: FAILED" in out
+    assert "#1: applied" not in out
+
+
+def test_classified_labels_are_written_back(monkeypatch, tmp_path, capsys):
+    labeled = {}
+    monkeypatch.setattr(backfill, "classify_issue", lambda *a, **k: ["bug"])
+    monkeypatch.setattr(backfill, "apply_labels",
+                        lambda number, labels, repo: labeled.__setitem__(number, labels) or True)
+    monkeypatch.setattr(backfill, "apply_native_targets", lambda *a, **k: True)
+    _run_main(monkeypatch, tmp_path, [],
+              [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": []}],
+              _NATIVE)
+    assert labeled == {"1": ["bug"]}
+    assert "#1: applied" in capsys.readouterr().out
+
+
+def test_existing_labels_are_not_rewritten(monkeypatch, tmp_path):
+    monkeypatch.setattr(backfill, "classify_issue",
+                        lambda *a, **k: pytest.fail("must not classify a labeled issue"))
+    monkeypatch.setattr(backfill, "apply_labels",
+                        lambda *a, **k: pytest.fail("must not re-apply an existing label"))
+    monkeypatch.setattr(backfill, "apply_native_targets", lambda *a, **k: True)
+    _run_main(monkeypatch, tmp_path, [],
+              [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": ["bug"]}],
+              _NATIVE)
+
+
+def test_node_id_from_listing_is_passed_through(monkeypatch, tmp_path):
+    seen = {}
+
+    def fake_apply(number, repo, labels, type_map, field_config, *, native=None, node_id=None):
+        seen["node_id"] = node_id
+        return True
+
+    monkeypatch.setattr(backfill, "apply_native_targets", fake_apply)
+    _run_main(monkeypatch, tmp_path, [],
+              [{"id": "N1", "number": 1, "title": "t", "body": "b", "label_names": ["bug"]}],
+              _NATIVE)
+    assert seen["node_id"] == "N1"

--- a/issue-labeler/test_backfill.py
+++ b/issue-labeler/test_backfill.py
@@ -1,0 +1,15 @@
+from backfill import decide_label
+
+
+def test_decide_label_reuses_existing_without_classifying():
+    def classify_fn():
+        raise AssertionError("must not classify when a label already exists")
+    assert decide_label(["bug", "area-tool"], {"bug", "enhancement"}, classify_fn) == "bug"
+
+
+def test_decide_label_classifies_when_missing():
+    assert decide_label(["area-tool"], {"bug", "enhancement"}, lambda: ["enhancement"]) == "enhancement"
+
+
+def test_decide_label_none_when_classify_empty():
+    assert decide_label([], {"bug"}, lambda: []) is None

--- a/issue-labeler/test_backfill.py
+++ b/issue-labeler/test_backfill.py
@@ -1,3 +1,8 @@
+import sys
+
+import backfill
+import pytest
+
 from backfill import decide_label
 
 
@@ -13,3 +18,18 @@ def test_decide_label_classifies_when_missing():
 
 def test_decide_label_none_when_classify_empty():
     assert decide_label([], {"bug"}, lambda: []) is None
+
+
+def test_dry_run_does_not_mutate(monkeypatch, tmp_path, capsys):
+    cfg = tmp_path / "type.yml"
+    cfg.write_text('labels:\n  bug:\n    description: "broken"\n    type: Bug\n')
+    monkeypatch.setattr(sys, "argv", ["backfill.py", "--repo", "o/r", "--type-config", str(cfg), "--dry-run"])
+    monkeypatch.setattr(backfill, "list_issues", lambda repo, state: [
+        {"number": 1, "title": "t", "body": "b", "label_names": ["bug"]},
+    ])
+    monkeypatch.setattr(backfill, "resolve_native_ids", lambda repo: {"types": {}, "fields": {}})
+    monkeypatch.setattr(backfill, "apply_native_targets", lambda *a, **k: pytest.fail("must not mutate in dry-run"))
+    backfill.main()
+    out = capsys.readouterr().out
+    assert "would apply" in out
+    assert "#1" in out

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -177,3 +177,35 @@ def test_apply_native_targets_uses_provided_native_without_resolving(monkeypatch
         native={"types": {"bug": "IT_bug"}, "fields": {}},
     )
     assert calls["type"] == ("ISSUE_NODE", "IT_bug")
+
+
+def test_main_native_block_failure_does_not_fail_workflow(monkeypatch, tmp_path, capsys):
+    """The additive native-targets block must never fail the run: a raising
+    apply_native_targets is downgraded to a warning, and main() still exits 0
+    after writing its label output."""
+    config = tmp_path / "type.yml"
+    config.write_text('labels:\n  bug:\n    description: "broken"\n    type: Bug\n')
+    output = tmp_path / "gh_output"
+
+    monkeypatch.setenv("CONFIG_PATH", str(config))
+    monkeypatch.setenv("GH_REPO", "o/r")
+    monkeypatch.setenv("ISSUE_TITLE", "something broke")
+    monkeypatch.setenv("ISSUE_BODY", "details")
+    monkeypatch.setenv("ISSUE_NUMBER", "7")
+    monkeypatch.setenv("EVENT_NAME", "issues")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    monkeypatch.setattr(classify, "classify_issue", lambda *a, **k: ["bug"])
+    monkeypatch.setattr(classify, "apply_labels", lambda n, labels: None)
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated API/permission failure")
+
+    monkeypatch.setattr(classify, "apply_native_targets", boom)
+
+    # Must return normally (no exception, no non-zero SystemExit).
+    classify.main()
+
+    out = capsys.readouterr().out
+    assert "::warning::Native type/field update skipped" in out
+    assert "labels=bug" in output.read_text()

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -7,6 +7,7 @@ accept labels from the configured allowlist. No Bedrock call is made.
 import pytest
 from pydantic import ValidationError
 
+import classify
 from classify import build_classification_model, build_system_prompt, parse_field_config, parse_label_type_map, parse_native_ids, sanitize, select_option, select_type
 
 
@@ -115,3 +116,42 @@ def test_select_option_returns_first_mapped_label():
     option_map = {"python": "Python", "typescript": "TypeScript"}
     assert select_option(["typescript"], option_map) == "TypeScript"
     assert select_option(["rust"], option_map) is None
+
+
+def test_apply_native_targets_sets_type_and_field(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: {
+        "types": {"bug": "IT_bug", "feature": "IT_feature"},
+        "fields": {"language": {"id": "IFSS_lang", "options": {"python": "OPT_py"}}},
+    })
+    monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: "ISSUE_NODE")
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)))
+    monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: calls.__setitem__("field", (node, fid, oid)))
+
+    classify.apply_native_targets(
+        "12", "o/r",
+        labels=["bug", "python"],
+        type_map={"bug": "Bug", "enhancement": "Feature"},
+        field_config={"name": "Language", "option_map": {"python": "Python"}},
+    )
+    assert calls["type"] == ("ISSUE_NODE", "IT_bug")
+    assert calls["field"] == ("ISSUE_NODE", "IFSS_lang", "OPT_py")
+
+
+def test_apply_native_targets_warns_and_skips_unknown_name(monkeypatch, capsys):
+    monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: {"types": {}, "fields": {}})
+    monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: "ISSUE_NODE")
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: pytest.fail("should not set"))
+    monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: pytest.fail("should not set"))
+
+    classify.apply_native_targets(
+        "12", "o/r", labels=["bug"],
+        type_map={"bug": "Bug"}, field_config=None,
+    )
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_apply_native_targets_noops_when_no_mapping_matches(monkeypatch):
+    monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: pytest.fail("should not resolve"))
+    # No type_map and no field_config -> nothing to do, must not even resolve.
+    classify.apply_native_targets("12", "o/r", labels=["bug"], type_map={}, field_config=None)

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -7,7 +7,7 @@ accept labels from the configured allowlist. No Bedrock call is made.
 import pytest
 from pydantic import ValidationError
 
-from classify import build_classification_model, build_system_prompt, sanitize
+from classify import build_classification_model, build_system_prompt, parse_field_config, parse_label_type_map, sanitize
 
 
 def test_accepts_allowlisted_labels():
@@ -38,3 +38,40 @@ def test_system_prompt_lists_labels_and_cap():
 def test_sanitize_strips_control_chars_and_truncates():
     assert sanitize("a\x00b\x1fc", 10) == "abc"
     assert sanitize("abcdef", 3) == "abc"
+
+
+def test_parse_label_type_map_extracts_only_typed_labels():
+    config = {
+        "labels": {
+            "bug": {"description": "broken", "type": "Bug"},
+            "enhancement": {"description": "new", "type": "Feature"},
+            "question": {"description": "asking"},      # no type -> omitted
+            "area-tool": "shorthand string",            # shorthand -> omitted
+        }
+    }
+    assert parse_label_type_map(config) == {"bug": "Bug", "enhancement": "Feature"}
+
+
+def test_parse_label_type_map_empty_when_none_typed():
+    config = {"labels": {"python": {"description": "py"}, "ts": "shorthand"}}
+    assert parse_label_type_map(config) == {}
+
+
+def test_parse_field_config_none_when_absent():
+    config = {"labels": {"bug": {"description": "x"}}}
+    assert parse_field_config(config) is None
+
+
+def test_parse_field_config_extracts_name_and_option_map():
+    config = {
+        "field": {"name": "Language"},
+        "labels": {
+            "python": {"description": "py", "option": "Python"},
+            "typescript": {"description": "ts", "option": "TypeScript"},
+            "other": {"description": "no option"},      # omitted from option_map
+        },
+    }
+    assert parse_field_config(config) == {
+        "name": "Language",
+        "option_map": {"python": "Python", "typescript": "TypeScript"},
+    }

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -15,8 +15,8 @@ from classify import (
     parse_label_type_map,
     parse_native_ids,
     sanitize,
-    select_option,
-    select_type,
+    select_mapped,
+    select_native_targets,
 )
 
 
@@ -87,6 +87,13 @@ def test_parse_field_config_extracts_name_and_option_map():
     }
 
 
+def test_parse_field_config_raises_on_malformed_block():
+    with pytest.raises(ValueError):
+        parse_field_config({"field": "Language", "labels": {}})
+    with pytest.raises(ValueError):
+        parse_field_config({"field": {}, "labels": {}})
+
+
 _SAMPLE_GRAPHQL_DATA = {
     "repository": {
         "issueTypes": {"nodes": [
@@ -114,17 +121,21 @@ def test_parse_native_ids_indexes_types_and_single_select_fields():
     assert "target date" not in ids["fields"]
 
 
-def test_select_type_returns_first_mapped_label():
+def test_select_mapped_returns_first_mapped_label():
     type_map = {"bug": "Bug", "enhancement": "Feature"}
-    assert select_type(["enhancement"], type_map) == "Feature"
-    assert select_type(["question"], type_map) is None
-    assert select_type([], type_map) is None
+    assert select_mapped(["enhancement"], type_map) == "Feature"
+    assert select_mapped(["question", "bug"], type_map) == "Bug"
+    assert select_mapped(["question"], type_map) is None
+    assert select_mapped([], type_map) is None
 
 
-def test_select_option_returns_first_mapped_label():
-    option_map = {"python": "Python", "typescript": "TypeScript"}
-    assert select_option(["typescript"], option_map) == "TypeScript"
-    assert select_option(["rust"], option_map) is None
+def test_select_native_targets_resolves_both_dimensions():
+    assert select_native_targets(
+        ["bug", "python"],
+        {"bug": "Bug"},
+        {"name": "Language", "option_map": {"python": "Python"}},
+    ) == ("Bug", "Python")
+    assert select_native_targets(["bug"], {}, None) == (None, None)
 
 
 def test_apply_native_targets_sets_type_and_field(monkeypatch):
@@ -134,15 +145,16 @@ def test_apply_native_targets_sets_type_and_field(monkeypatch):
         "fields": {"language": {"id": "IFSS_lang", "options": {"python": "OPT_py"}}},
     })
     monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: "ISSUE_NODE")
-    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)))
-    monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: calls.__setitem__("field", (node, fid, oid)))
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)) or True)
+    monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: calls.__setitem__("field", (node, fid, oid)) or True)
 
-    classify.apply_native_targets(
+    ok = classify.apply_native_targets(
         "12", "o/r",
         labels=["bug", "python"],
         type_map={"bug": "Bug", "enhancement": "Feature"},
         field_config={"name": "Language", "option_map": {"python": "Python"}},
     )
+    assert ok is True
     assert calls["type"] == ("ISSUE_NODE", "IT_bug")
     assert calls["field"] == ("ISSUE_NODE", "IFSS_lang", "OPT_py")
 
@@ -153,50 +165,70 @@ def test_apply_native_targets_warns_and_skips_unknown_name(monkeypatch, capsys):
     monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: pytest.fail("should not set"))
     monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: pytest.fail("should not set"))
 
-    classify.apply_native_targets(
+    ok = classify.apply_native_targets(
         "12", "o/r", labels=["bug"],
         type_map={"bug": "Bug"}, field_config=None,
     )
+    assert ok is False
     assert "::warning::" in capsys.readouterr().out
 
 
 def test_apply_native_targets_noops_when_no_mapping_matches(monkeypatch):
     monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: pytest.fail("should not resolve"))
     # No type_map and no field_config -> nothing to do, must not even resolve.
-    classify.apply_native_targets("12", "o/r", labels=["bug"], type_map={}, field_config=None)
+    assert classify.apply_native_targets("12", "o/r", labels=["bug"], type_map={}, field_config=None) is True
 
 
-def test_apply_native_targets_uses_provided_native_without_resolving(monkeypatch):
+def test_apply_native_targets_uses_provided_native_and_node_id(monkeypatch):
     calls = {}
     monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: pytest.fail("should not resolve when native provided"))
-    monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: "ISSUE_NODE")
-    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)))
+    monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: pytest.fail("should not fetch when node_id provided"))
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)) or True)
     monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: pytest.fail("no field expected"))
-    classify.apply_native_targets(
+    ok = classify.apply_native_targets(
         "12", "o/r", labels=["bug"], type_map={"bug": "Bug"}, field_config=None,
         native={"types": {"bug": "IT_bug"}, "fields": {}},
+        node_id="ISSUE_NODE",
     )
+    assert ok is True
     assert calls["type"] == ("ISSUE_NODE", "IT_bug")
+
+
+def test_apply_native_targets_reports_mutation_failure(monkeypatch):
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: False)
+    ok = classify.apply_native_targets(
+        "12", "o/r", labels=["bug"], type_map={"bug": "Bug"}, field_config=None,
+        native={"types": {"bug": "IT_bug"}, "fields": {}},
+        node_id="ISSUE_NODE",
+    )
+    assert ok is False
+
+
+def _set_main_env(monkeypatch, tmp_path, config_text):
+    config = tmp_path / "config.yml"
+    config.write_text(config_text)
+    output = tmp_path / "gh_output"
+    monkeypatch.setenv("CONFIG_PATH", str(config))
+    monkeypatch.setenv("GH_REPO", "o/r")
+    monkeypatch.setenv("ISSUE_TITLE", "something broke")
+    monkeypatch.setenv("ISSUE_BODY", "details")
+    monkeypatch.setenv("ISSUE_NUMBER", "7")
+    monkeypatch.setenv("ISSUE_NODE_ID", "ISSUE_NODE")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    return output
 
 
 def test_main_native_block_failure_does_not_fail_workflow(monkeypatch, tmp_path, capsys):
     """The additive native-targets block must never fail the run: a raising
     apply_native_targets is downgraded to a warning, and main() still exits 0
     after writing its label output."""
-    config = tmp_path / "type.yml"
-    config.write_text('labels:\n  bug:\n    description: "broken"\n    type: Bug\n')
-    output = tmp_path / "gh_output"
-
-    monkeypatch.setenv("CONFIG_PATH", str(config))
-    monkeypatch.setenv("GH_REPO", "o/r")
-    monkeypatch.setenv("ISSUE_TITLE", "something broke")
-    monkeypatch.setenv("ISSUE_BODY", "details")
-    monkeypatch.setenv("ISSUE_NUMBER", "7")
-    monkeypatch.setenv("EVENT_NAME", "issues")
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    output = _set_main_env(
+        monkeypatch, tmp_path,
+        'labels:\n  bug:\n    description: "broken"\n    type: Bug\n',
+    )
 
     monkeypatch.setattr(classify, "classify_issue", lambda *a, **k: ["bug"])
-    monkeypatch.setattr(classify, "apply_labels", lambda n, labels: None)
+    monkeypatch.setattr(classify, "apply_labels", lambda n, labels, repo: True)
 
     def boom(*a, **k):
         raise RuntimeError("simulated API/permission failure")
@@ -209,3 +241,37 @@ def test_main_native_block_failure_does_not_fail_workflow(monkeypatch, tmp_path,
     out = capsys.readouterr().out
     assert "::warning::Native type/field update skipped" in out
     assert "labels=bug" in output.read_text()
+
+
+def test_main_skips_native_block_without_issue_node_id(monkeypatch, tmp_path, capsys):
+    """Events without an issue payload (PRs) must skip the native block, with a log line."""
+    output = _set_main_env(
+        monkeypatch, tmp_path,
+        'labels:\n  bug:\n    description: "broken"\n    type: Bug\n',
+    )
+    monkeypatch.delenv("ISSUE_NODE_ID")
+
+    monkeypatch.setattr(classify, "classify_issue", lambda *a, **k: ["bug"])
+    monkeypatch.setattr(classify, "apply_labels", lambda n, labels, repo: True)
+    monkeypatch.setattr(classify, "apply_native_targets", lambda *a, **k: pytest.fail("must not run without an issue node id"))
+
+    classify.main()
+
+    out = capsys.readouterr().out
+    assert "skipping native type/field update" in out
+    assert "labels=bug" in output.read_text()
+
+
+def test_main_fails_loudly_on_malformed_field_config(monkeypatch, tmp_path, capsys):
+    """A malformed `field:` block is a config error and must fail the run,
+    matching how a malformed `labels:` block behaves."""
+    _set_main_env(
+        monkeypatch, tmp_path,
+        'field: Language\nlabels:\n  python:\n    description: "py"\n    option: Python\n',
+    )
+    monkeypatch.setattr(classify, "classify_issue", lambda *a, **k: pytest.fail("must fail before classifying"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        classify.main()
+    assert excinfo.value.code == 1
+    assert "::error::" in capsys.readouterr().out

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -8,7 +8,16 @@ import pytest
 from pydantic import ValidationError
 
 import classify
-from classify import build_classification_model, build_system_prompt, parse_field_config, parse_label_type_map, parse_native_ids, sanitize, select_option, select_type
+from classify import (
+    build_classification_model,
+    build_system_prompt,
+    parse_field_config,
+    parse_label_type_map,
+    parse_native_ids,
+    sanitize,
+    select_option,
+    select_type,
+)
 
 
 def test_accepts_allowlisted_labels():
@@ -155,3 +164,16 @@ def test_apply_native_targets_noops_when_no_mapping_matches(monkeypatch):
     monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: pytest.fail("should not resolve"))
     # No type_map and no field_config -> nothing to do, must not even resolve.
     classify.apply_native_targets("12", "o/r", labels=["bug"], type_map={}, field_config=None)
+
+
+def test_apply_native_targets_uses_provided_native_without_resolving(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(classify, "resolve_native_ids", lambda repo: pytest.fail("should not resolve when native provided"))
+    monkeypatch.setattr(classify, "get_issue_node_id", lambda n, repo: "ISSUE_NODE")
+    monkeypatch.setattr(classify, "set_issue_type", lambda node, tid: calls.__setitem__("type", (node, tid)))
+    monkeypatch.setattr(classify, "set_issue_field", lambda node, fid, oid: pytest.fail("no field expected"))
+    classify.apply_native_targets(
+        "12", "o/r", labels=["bug"], type_map={"bug": "Bug"}, field_config=None,
+        native={"types": {"bug": "IT_bug"}, "fields": {}},
+    )
+    assert calls["type"] == ("ISSUE_NODE", "IT_bug")

--- a/issue-labeler/test_classify.py
+++ b/issue-labeler/test_classify.py
@@ -7,7 +7,7 @@ accept labels from the configured allowlist. No Bedrock call is made.
 import pytest
 from pydantic import ValidationError
 
-from classify import build_classification_model, build_system_prompt, parse_field_config, parse_label_type_map, sanitize
+from classify import build_classification_model, build_system_prompt, parse_field_config, parse_label_type_map, parse_native_ids, sanitize, select_option, select_type
 
 
 def test_accepts_allowlisted_labels():
@@ -75,3 +75,43 @@ def test_parse_field_config_extracts_name_and_option_map():
         "name": "Language",
         "option_map": {"python": "Python", "typescript": "TypeScript"},
     }
+
+
+_SAMPLE_GRAPHQL_DATA = {
+    "repository": {
+        "issueTypes": {"nodes": [
+            {"id": "IT_bug", "name": "Bug"},
+            {"id": "IT_feature", "name": "Feature"},
+        ]},
+        "issueFields": {"nodes": [
+            {"__typename": "IssueFieldSingleSelect", "id": "IFSS_lang", "name": "Language",
+             "options": [
+                 {"id": "OPT_py", "name": "Python"},
+                 {"id": "OPT_ts", "name": "TypeScript"},
+             ]},
+            {"__typename": "IssueFieldDate", "id": "IFD_x", "name": "Target date"},
+        ]},
+    }
+}
+
+
+def test_parse_native_ids_indexes_types_and_single_select_fields():
+    ids = parse_native_ids(_SAMPLE_GRAPHQL_DATA)
+    assert ids["types"] == {"bug": "IT_bug", "feature": "IT_feature"}
+    assert ids["fields"]["language"]["id"] == "IFSS_lang"
+    assert ids["fields"]["language"]["options"] == {"python": "OPT_py", "typescript": "OPT_ts"}
+    # non-single-select fields are skipped
+    assert "target date" not in ids["fields"]
+
+
+def test_select_type_returns_first_mapped_label():
+    type_map = {"bug": "Bug", "enhancement": "Feature"}
+    assert select_type(["enhancement"], type_map) == "Feature"
+    assert select_type(["question"], type_map) is None
+    assert select_type([], type_map) is None
+
+
+def test_select_option_returns_first_mapped_label():
+    option_map = {"python": "Python", "typescript": "TypeScript"}
+    assert select_option(["typescript"], option_map) == "TypeScript"
+    assert select_option(["rust"], option_map) is None


### PR DESCRIPTION
## What

Extends the `issue-labeler` action so that, **for issues only**, it also sets the org's native **issue Type** and the **Language** issue field, mapped from the labels it already classifies. This is purely additive: the existing label classification and application are unchanged.

These features do not apply to pull requests, so the new behavior self-gates on `github.event_name == 'issues'`.

## How

- **Config (back-compatible):** a label may declare a `type:` (maps to a native issue type), and a config may declare a top-level `field:` block with per-label `option:` keys (maps to a single-select issue field). Existing string/`description` config forms keep working untouched.
- **Runtime ID resolution:** human-readable names (`Bug`, `Language`, `Python`) are resolved to GraphQL node IDs via a repo-level query, matched case-insensitively. No org IDs are hardcoded.
- **Mutations:** `updateIssueIssueType` and `setIssueFieldValue`. Existing values are overwritten.
- **Strictly non-fatal:** the whole native block is best-effort. Any failure (missing `gh`, malformed field config, API/permission error) is downgraded to a `::warning::` and the workflow stays green. Labels are applied before this block runs.
- **Backfill:** `backfill.py` applies the same logic to existing issues (all states), reusing existing labels where present and only calling the LLM for issues missing one. Supports `--dry-run`.

## Security model

Unchanged. The LLM still has no tools and its output is constrained to the enum allowlist. The new code acts only on those allowlisted labels routed through static, operator-authored config; it never receives free-form LLM text. Worst case remains mislabeling.

## Testing

- 21 unit tests pass (`pytest test_classify.py test_backfill.py`), covering config parsing, ID indexing, label→target mapping, event gating, the non-fatal guard, and the backfill decision logic. GitHub I/O is mocked.
- Not yet verified at runtime: whether the Actions `GITHUB_TOKEN` (`issues: write`) can perform the type/field mutations. The non-fatal guard means a permission gap surfaces as a warning, not a failed run. Will confirm against a live issue and add a PAT fallback if needed.

## Follow-up

Consuming-repo config changes (`harness-sdk`, `evals`: add `design`/`blog` labels, add `type:`/`field:` mappings) ship as separate PRs once this merges.
