### PR TITLE
learn: add reviewer constraints from PR #2954

### DIFF
--- a/strands-command/agent-sops/task-reviewer.sop.md
+++ b/strands-command/agent-sops/task-reviewer.sop.md
@@ -245,3 +245,10 @@ If you disagree with the approach:
 - Reference project guidelines and standards
 - Suggest alternative approaches
 - Be open to discussion and learning
+
+## Learned Constraints
+
+These constraints are appended over time from lessons learned on merged PRs. Each is a durable, generalizable review rule.
+
+- You MUST, when reviewing a fix to a locking/concurrency bug, verify the fix enforces the real ownership / acquire-release pairing invariant rather than a proxy: a lock must be released only by the code path that proved it acquired it (mirror the acquire result, as `tools/_caller.py` does with `if acquired_lock: release_lock()`), never based on a re-derived `mode`/config flag. Flag any `release()` conditioned on configuration instead of proven acquisition, and flag any field named like `lock_acquired`/`owns_lock` whose value does not actually track acquisition in every mode. (from strands-agents/harness-sdk#2954)
+- You MUST, when a PR fixes a bug that links to an issue documenting a deeper root cause, check whether the change resolves that root cause or only the immediate symptom; if it is a narrower symptom fix, confirm a tracking issue exists for the remaining root cause and flag its absence rather than treating the bug as fully closed. (from strands-agents/harness-sdk#2954)


### PR DESCRIPTION
Appends a new `## Learned Constraints` section to `strands-command/agent-sops/task-reviewer.sop.md` with two durable, generalizable review rules learned from the lifecycle of strands-agents/harness-sdk#2954 and its root-cause issue #2918. No existing section is modified.

1. For lock/concurrency fixes: release a lock only by the path that proved it acquired it (mirror the acquire result, as `tools/_caller.py` does), never via a re-derived `mode`/config proxy; flag ownership-named fields that aren't true in every mode.
2. For bugfixes linked to a root-cause issue: confirm the change resolves the documented root cause or that a tracking issue exists for the remainder, rather than treating a symptom fix as fully closing the bug.

Run: learning-run-pr2954