### PR TITLE
fix(cdk-evals): deny dashboard deploy when auth secret is unavailable

### DIFF
--- a/cdk-evals/README.md
+++ b/cdk-evals/README.md
@@ -78,7 +78,7 @@ npm run deploy:pipeline
        --secret-string '{"LANGFUSE_SECRET_KEY":"sk-...","LANGFUSE_PUBLIC_KEY":"pk-...","LANGFUSE_HOST":"https://your-langfuse-host.com"}'
    ```
 
-> **Note:** Dashboard auth credentials are read from Secrets Manager at CDK synth time and injected into Lambda@Edge. If you deploy without creating the secret first, placeholder values will be used and authentication won't work.
+> **Note:** Dashboard auth credentials are read from Secrets Manager at CDK synth time and injected into Lambda@Edge. The secret must exist before deployment. If it is missing or unreadable, synthesis fails so the dashboard is never deployed without configured credentials.
 
 ## Stack Outputs
 
@@ -130,7 +130,7 @@ aws secretsmanager put-secret-value \
 npm run deploy:dashboard
 ```
 
-> **Important:** Credentials are baked into the Lambda function at deploy time. You must redeploy after changing the secret for changes to take effect. The secret must exist before deployment or placeholder values will be used.
+> **Important:** Credentials are baked into the Lambda function at deploy time. You must redeploy after changing the secret for changes to take effect. The secret must exist before deployment; otherwise synthesis fails and the stack is not deployed.
 
 ## Useful Commands
 

--- a/cdk-evals/lambda/basic-auth/index.js
+++ b/cdk-evals/lambda/basic-auth/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
 // Basic Auth credentials for Strands Evals Dashboard
-// These placeholders are replaced at CDK deploy time with values from Secrets Manager
-const USERNAME = '__BASIC_AUTH_USERNAME__';
-const PASSWORD = '__BASIC_AUTH_PASSWORD__';
+// These placeholders are replaced at CDK deploy time with JSON-encoded string
+// literals built from values in Secrets Manager (see dashboard-stack.ts).
+const USERNAME = __BASIC_AUTH_USERNAME__;
+const PASSWORD = __BASIC_AUTH_PASSWORD__;
 
 // Pre-compute the expected Authorization header value
 const EXPECTED_AUTH = 'Basic ' + Buffer.from(`${USERNAME}:${PASSWORD}`).toString('base64');

--- a/cdk-evals/lib/dashboard-stack.ts
+++ b/cdk-evals/lib/dashboard-stack.ts
@@ -13,8 +13,11 @@ const SECRET_NAME = "strands-evals/dashboard-auth";
 
 /**
  * Fetches auth credentials from Secrets Manager at synth time.
- * Creates the secret with default values if it doesn't exist.
- * Returns { username, password } or null if in CI/bootstrap mode.
+ * Returns { username, password } when the secret is readable. Returns null
+ * only when the secret is unreadable/absent or when running in bootstrap/skip
+ * mode. The secret is never created and no default values are supplied. When
+ * this returns null the caller throws (fail-closed) so deployment is denied
+ * unless real credentials are available.
  */
 function fetchAuthCredentials(): { username: string; password: string } | null {
   // Skip fetching during bootstrap or when AWS credentials aren't available
@@ -68,10 +71,14 @@ export class DashboardStack extends cdk.Stack {
     const lambdaTemplatePath = path.join(__dirname, "../lambda/basic-auth/index.js");
     const lambdaTemplate = fs.readFileSync(lambdaTemplatePath, "utf-8");
 
-    // Replace placeholders with actual credentials
+    // Replace placeholders with JSON-encoded string literals. JSON.stringify
+    // safely escapes quotes, backslashes, backticks, and ${...} sequences so a
+    // credential value cannot corrupt or inject code into the generated Lambda.
+    // Use function replacers so "$" sequences in the JSON-encoded credential
+    // are inserted literally rather than interpreted by String.replace.
     const lambdaCode = lambdaTemplate
-      .replace("__BASIC_AUTH_USERNAME__", username)
-      .replace("__BASIC_AUTH_PASSWORD__", password);
+      .replace("__BASIC_AUTH_USERNAME__", () => JSON.stringify(username))
+      .replace("__BASIC_AUTH_PASSWORD__", () => JSON.stringify(password));
 
     // Lambda@Edge for Basic Authentication with injected credentials
     const basicAuthFunction = new cloudfront.experimental.EdgeFunction(

--- a/cdk-evals/lib/dashboard-stack.ts
+++ b/cdk-evals/lib/dashboard-stack.ts
@@ -31,7 +31,7 @@ function fetchAuthCredentials(): { username: string; password: string } | null {
     );
     return JSON.parse(result.trim());
   } catch {
-    console.log(`Secret "${SECRET_NAME}" not found or not accessible. Using placeholders.`);
+    console.log(`Secret "${SECRET_NAME}" not found or not accessible.`);
     console.log('Create the secret first with: aws secretsmanager create-secret --name "strands-evals/dashboard-auth" --secret-string \'{"username":"your-user","password":"your-pass"}\'');
     return null;
   }
@@ -52,10 +52,17 @@ export class DashboardStack extends cdk.Stack {
       encryption: s3.BucketEncryption.S3_MANAGED,
     });
 
-    // Fetch credentials from Secrets Manager at synth time
+    // Fetch credentials from Secrets Manager at synth time.
+    // Deny deployment when credentials are unavailable so the dashboard is
+    // never served with anything other than the configured secret values.
     const credentials = fetchAuthCredentials();
-    const username = credentials?.username ?? "__PLACEHOLDER_USERNAME__";
-    const password = credentials?.password ?? "__PLACEHOLDER_PASSWORD__";
+    if (!credentials?.username || !credentials?.password) {
+      throw new Error(
+        `Dashboard auth credentials are unavailable. Create the secret "${SECRET_NAME}" before deploying:\n` +
+          `aws secretsmanager create-secret --name "${SECRET_NAME}" --secret-string '{"username":"your-username","password":"your-password"}'`
+      );
+    }
+    const { username, password } = credentials;
 
     // Read the Lambda template and inject credentials
     const lambdaTemplatePath = path.join(__dirname, "../lambda/basic-auth/index.js");


### PR DESCRIPTION
The evals dashboard stack reads basic-auth credentials from the `strands-evals/dashboard-auth` Secrets Manager secret at synth time and injects them into the Lambda@Edge function. When the secret was absent, the stack fell back to fixed placeholder values, so the dashboard could be deployed and served with credentials that are not the ones an operator configured.

## Change

- Require the auth credentials to be present and readable before the Lambda@Edge auth function is built.
- If the credentials are unavailable, CDK synthesis now fails with guidance to create the secret, instead of deploying the dashboard with placeholder values.
- Update the README notes to describe the new behavior.

This makes the dashboard deny access by default: it is never deployed without the configured credentials in place.

## Testing

- `cd cdk-evals && npx tsc --noEmit lib/dashboard-stack.ts` (with project compiler options) passes with no errors.
- This CDK package has no unit-test harness (the `build` script is just `tsc`, and there are no `*.test.ts` files or test runner dependencies), so no regression test was added.